### PR TITLE
fix(registry): atomic discover() — closes #11

### DIFF
--- a/src/safe_agent/modules/registry.py
+++ b/src/safe_agent/modules/registry.py
@@ -121,12 +121,12 @@ class ModuleRegistry:
             ValueError: If namespace or tool name collisions occur during
                 registration.
 
-        Warning:
-            If ``discover()`` raises mid-loop, any entry points processed
-            before the failure are already registered and the registry state
-            is partially populated. Discard the registry and create a new
-            instance rather than retrying discovery on a failed registry.
-            See issue #11 for atomic discovery support.
+        Note:
+            ``discover()`` is atomic: all validation and instantiation run
+            against staging dicts before any live state is modified. If an
+            error occurs at any point, the registry is left in its
+            pre-discover state — no partial registration occurs. Fixes
+            issue #11.
         """
         if self._discovered:
             raise RuntimeError(
@@ -135,6 +135,15 @@ class ModuleRegistry:
             )
 
         eps = entry_points(group="safe_agent.modules")
+
+        # Use staging dicts so that discover() is all-or-nothing. If anything
+        # fails mid-loop the live maps are never touched and the registry
+        # remains in its pre-discover state.
+        staging_namespace_map: dict[str, BaseModule] = dict(self._namespace_map)
+        staging_tool_map: dict[str, tuple[BaseModule, ToolDescriptor]] = dict(
+            self._tool_map
+        )
+
         try:
             for ep in eps:
                 module_class = ep.load()
@@ -154,19 +163,50 @@ class ModuleRegistry:
                         f"may be registered."
                     )
                 instance: BaseModule = module_class()
-                self.register(instance)
+                descriptor = instance.describe()
+                namespace = descriptor.namespace
+                tools = list(descriptor.tools)
+
+                # Namespace collision check against staging state.
+                if namespace in staging_namespace_map:
+                    existing = staging_namespace_map[namespace]
+                    if existing is not instance:
+                        raise ValueError(
+                            f"Namespace collision: '{namespace}' is already "
+                            f"registered by {existing!r}."
+                        )
+                    # Same instance — idempotent, skip.
+                    continue
+
+                # Tool collision check against staging state.
+                for tool in tools:
+                    if tool.name in staging_tool_map:
+                        existing_module, _ = staging_tool_map[tool.name]
+                        raise ValueError(
+                            f"Tool name collision: '{tool.name}' is already "
+                            f"registered by {existing_module!r}. "
+                            f"Tool names must be unique across all modules."
+                        )
+
+                # All checks passed — write to staging only.
+                staging_namespace_map[namespace] = instance
+                for tool in tools:
+                    staging_tool_map[tool.name] = (instance, tool)
+
                 logger.info(
                     "safe_agent.modules: registered '%s' from entry point '%s'",
                     instance,
                     ep.name,
                 )
         except Exception:
-            # Discovery failed — do not mark as completed so callers can
-            # diagnose and retry with a fresh registry.
+            # Discovery failed — staging dicts are discarded, live maps
+            # untouched. Do not mark as completed.
             raise
-        else:
-            # Only mark discovered after the loop completes successfully.
-            self._discovered = True
+
+        # All entry points processed successfully — atomic swap.
+        self._namespace_map = staging_namespace_map
+        self._tool_map = staging_tool_map
+        self._discovered = True
 
     def get_tool(self, tool_name: str) -> tuple[BaseModule, ToolDescriptor] | None:
         """Look up a tool by its fully-qualified name.

--- a/tests/test_modules/test_registry.py
+++ b/tests/test_modules/test_registry.py
@@ -276,6 +276,110 @@ class TestModuleRegistry:
         # Registry should NOT be marked as discovered after failure.
         assert registry._discovered is False
 
+    def test_discover_is_atomic_no_partial_state_on_type_error(self) -> None:
+        """discover() must leave registry unchanged when it fails mid-loop.
+
+        First entry point loads a valid module; second raises TypeError.
+        Neither should appear in the registry after the failure.
+        Fixes issue #11.
+        """
+        good_instance = _make_module("good", ["good:Op"])
+        GoodClass = type(good_instance)
+
+        class NotAModule:
+            """Not a module."""
+
+        good_ep = MagicMock()
+        good_ep.name = "good_ep"
+        good_ep.value = "pkg:GoodModule"
+        good_ep.load.return_value = GoodClass
+
+        bad_ep = MagicMock()
+        bad_ep.name = "bad_ep"
+        bad_ep.value = "pkg:NotAModule"
+        bad_ep.load.return_value = NotAModule
+
+        registry = ModuleRegistry()
+        with patch(
+            "safe_agent.modules.registry.entry_points",
+            return_value=[good_ep, bad_ep],
+        ):
+            with pytest.raises(TypeError):
+                registry.discover()
+
+        # Both the valid entry point and the failed one must be absent.
+        assert registry.get_module("good") is None
+        assert registry.get_tool("good:Op") is None
+        assert registry._discovered is False
+
+    def test_discover_is_atomic_no_partial_state_on_collision(self) -> None:
+        """discover() must leave registry unchanged when a collision occurs.
+
+        First entry point loads fine; second collides on tool name.
+        Neither should pollute the live registry. Fixes issue #11.
+        """
+        first_instance = _make_module("first", ["shared:Tool"])
+        FirstClass = type(first_instance)
+
+        second_instance = _make_module("second", ["shared:Tool"])
+        SecondClass = type(second_instance)
+
+        ep1 = MagicMock()
+        ep1.name = "ep1"
+        ep1.value = "pkg:First"
+        ep1.load.return_value = FirstClass
+
+        ep2 = MagicMock()
+        ep2.name = "ep2"
+        ep2.value = "pkg:Second"
+        ep2.load.return_value = SecondClass
+
+        registry = ModuleRegistry()
+        with patch(
+            "safe_agent.modules.registry.entry_points",
+            return_value=[ep1, ep2],
+        ):
+            with pytest.raises(ValueError, match="Tool name collision"):
+                registry.discover()
+
+        assert registry.get_module("first") is None
+        assert registry.get_module("second") is None
+        assert registry.get_tool("shared:Tool") is None
+        assert registry._discovered is False
+
+    def test_discover_atomic_preserves_pre_existing_manual_registrations(
+        self,
+    ) -> None:
+        """A failed discover() must not disturb manually registered modules.
+
+        If register() was called before discover(), and discover() then fails,
+        the manually registered module must still be present.
+        """
+        manual = _make_module("manual", ["manual:Op"])
+
+        class NotAModule:
+            """Not a module."""
+
+        bad_ep = MagicMock()
+        bad_ep.name = "bad_ep"
+        bad_ep.value = "pkg:Bad"
+        bad_ep.load.return_value = NotAModule
+
+        registry = ModuleRegistry()
+        registry.register(manual)
+
+        with patch(
+            "safe_agent.modules.registry.entry_points",
+            return_value=[bad_ep],
+        ):
+            with pytest.raises(TypeError):
+                registry.discover()
+
+        # Manual registration must be intact.
+        assert registry.get_module("manual") is manual
+        assert registry.get_tool("manual:Op") is not None
+        assert registry._discovered is False
+
     # ---------------------------------------------------------------------------
     # dispatch() tests
     # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #11: `ModuleRegistry.discover()` leaves partial state on mid-loop failure.

### What changed

**`src/safe_agent/modules/registry.py`**
- `discover()` now builds staging copies of `_namespace_map` and `_tool_map` before touching any live state
- All validation (type check, namespace collision, tool collision) runs against the staging dicts
- On success: atomic swap — live maps replaced in a single assignment pair, then `_discovered = True`
- On any exception: staging dicts discarded, live maps untouched, `_discovered` stays `False`
- Pre-existing manually registered modules are preserved across a failed `discover()`
- Updated docstring: removed known-limitation warning, documented atomic guarantee

### Tests added (3 new)

- `test_discover_is_atomic_no_partial_state_on_type_error`
- `test_discover_is_atomic_no_partial_state_on_collision`
- `test_discover_atomic_preserves_pre_existing_manual_registrations`

### CI

✅ ruff lint + format  
✅ mypy  
✅ pytest: 95 passed