### PR TITLE
fix(registry): address PR #13 review follow-ups

### DIFF
--- a/src/safe_agent/modules/registry.py
+++ b/src/safe_agent/modules/registry.py
@@ -23,7 +23,11 @@ class ModuleRegistry:
       shadowing).
     - Registering the *same* instance twice is idempotent and a no-op.
 
-    ``discover()`` is call-once; subsequent calls raise ``RuntimeError``.
+    ``discover()`` may be retried after a failure. After a successful call,
+    subsequent calls raise ``RuntimeError``.
+
+    This class is not thread-safe. External synchronization is required for
+    concurrent access.
 
     Security note: ``discover()`` loads and instantiates code from installed
     packages that declare a ``safe_agent.modules`` entry point. This is only
@@ -144,64 +148,57 @@ class ModuleRegistry:
             self._tool_map
         )
 
-        try:
-            for ep in eps:
-                module_class = ep.load()
-                logger.info(
-                    "safe_agent.modules: loading entry point '%s' (%s)",
-                    ep.name,
-                    ep.value,
+        for ep in eps:
+            module_class = ep.load()
+            logger.info(
+                "safe_agent.modules: loading entry point '%s' (%s)",
+                ep.name,
+                ep.value,
+            )
+            if not (
+                isinstance(module_class, type) and issubclass(module_class, BaseModule)
+            ):
+                raise TypeError(
+                    f"Entry point '{ep.name}' ({ep.value}) loaded "
+                    f"{module_class!r}, which is not a subclass of "
+                    f"BaseModule. Only trusted BaseModule subclasses "
+                    f"may be registered."
                 )
-                if not (
-                    isinstance(module_class, type)
-                    and issubclass(module_class, BaseModule)
-                ):
-                    raise TypeError(
-                        f"Entry point '{ep.name}' ({ep.value}) loaded "
-                        f"{module_class!r}, which is not a subclass of "
-                        f"BaseModule. Only trusted BaseModule subclasses "
-                        f"may be registered."
+            instance: BaseModule = module_class()
+            descriptor = instance.describe()
+            namespace = descriptor.namespace
+            tools = list(descriptor.tools)
+
+            # Namespace collision check against staging state.
+            if namespace in staging_namespace_map:
+                existing = staging_namespace_map[namespace]
+                raise ValueError(
+                    f"Namespace collision: '{namespace}' is already "
+                    f"registered by {existing!r}."
+                )
+
+            # Tool collision check against staging state.
+            for tool in tools:
+                if tool.name in staging_tool_map:
+                    existing_module, _ = staging_tool_map[tool.name]
+                    raise ValueError(
+                        f"Tool name collision: '{tool.name}' is already "
+                        f"registered by {existing_module!r}. "
+                        f"Tool names must be unique across all modules."
                     )
-                instance: BaseModule = module_class()
-                descriptor = instance.describe()
-                namespace = descriptor.namespace
-                tools = list(descriptor.tools)
 
-                # Namespace collision check against staging state.
-                if namespace in staging_namespace_map:
-                    existing = staging_namespace_map[namespace]
-                    if existing is not instance:
-                        raise ValueError(
-                            f"Namespace collision: '{namespace}' is already "
-                            f"registered by {existing!r}."
-                        )
-                    # Same instance — idempotent, skip.
-                    continue
+            # All checks passed — write to staging only. If anything below
+            # raises, these local dicts are discarded and live state remains
+            # untouched.
+            staging_namespace_map[namespace] = instance
+            for tool in tools:
+                staging_tool_map[tool.name] = (instance, tool)
 
-                # Tool collision check against staging state.
-                for tool in tools:
-                    if tool.name in staging_tool_map:
-                        existing_module, _ = staging_tool_map[tool.name]
-                        raise ValueError(
-                            f"Tool name collision: '{tool.name}' is already "
-                            f"registered by {existing_module!r}. "
-                            f"Tool names must be unique across all modules."
-                        )
-
-                # All checks passed — write to staging only.
-                staging_namespace_map[namespace] = instance
-                for tool in tools:
-                    staging_tool_map[tool.name] = (instance, tool)
-
-                logger.info(
-                    "safe_agent.modules: registered '%s' from entry point '%s'",
-                    instance,
-                    ep.name,
-                )
-        except Exception:
-            # Discovery failed — staging dicts are discarded, live maps
-            # untouched. Do not mark as completed.
-            raise
+            logger.info(
+                "safe_agent.modules: registered '%s' from entry point '%s'",
+                instance,
+                ep.name,
+            )
 
         # All entry points processed successfully — atomic swap.
         self._namespace_map = staging_namespace_map

--- a/tests/test_modules/test_registry.py
+++ b/tests/test_modules/test_registry.py
@@ -380,6 +380,81 @@ class TestModuleRegistry:
         assert registry.get_tool("manual:Op") is not None
         assert registry._discovered is False
 
+    def test_discover_can_be_retried_after_failure(self) -> None:
+        """discover() should be retryable after a failed attempt.
+
+        A failure must leave ``_discovered`` false so a later clean retry can
+        succeed on the same registry instance.
+        """
+
+        class NotAModule:
+            """Not a module."""
+
+        bad_ep = MagicMock()
+        bad_ep.name = "bad_ep"
+        bad_ep.value = "pkg:Bad"
+        bad_ep.load.return_value = NotAModule
+
+        good_instance = _make_module("retry", ["retry:Op"])
+        GoodClass = type(good_instance)
+
+        good_ep = MagicMock()
+        good_ep.name = "good_ep"
+        good_ep.value = "pkg:RetryModule"
+        good_ep.load.return_value = GoodClass
+
+        registry = ModuleRegistry()
+        with patch(
+            "safe_agent.modules.registry.entry_points",
+            return_value=[bad_ep],
+        ):
+            with pytest.raises(TypeError):
+                registry.discover()
+
+        assert registry._discovered is False
+
+        with patch(
+            "safe_agent.modules.registry.entry_points",
+            return_value=[good_ep],
+        ):
+            registry.discover()
+
+        assert registry._discovered is True
+        assert registry.get_module("retry") is not None
+        assert registry.get_tool("retry:Op") is not None
+
+    def test_discover_rejects_namespace_collision_with_manual_registration(
+        self,
+    ) -> None:
+        """discover() should reject namespace collisions against live state.
+
+        Pre-existing manual registrations must be included in the staging copy,
+        and a colliding discovered module must fail without changing live state.
+        """
+        manual = _make_module("shared", ["shared:Manual"])
+        discovered = _make_module("shared", ["shared:Discovered"])
+        DiscoveredClass = type(discovered)
+
+        ep = MagicMock()
+        ep.name = "shared_ep"
+        ep.value = "pkg:SharedModule"
+        ep.load.return_value = DiscoveredClass
+
+        registry = ModuleRegistry()
+        registry.register(manual)
+
+        with patch(
+            "safe_agent.modules.registry.entry_points",
+            return_value=[ep],
+        ):
+            with pytest.raises(ValueError, match="Namespace collision"):
+                registry.discover()
+
+        assert registry.get_module("shared") is manual
+        assert registry.get_tool("shared:Manual") is not None
+        assert registry.get_tool("shared:Discovered") is None
+        assert registry._discovered is False
+
     # ---------------------------------------------------------------------------
     # dispatch() tests
     # ---------------------------------------------------------------------------


### PR DESCRIPTION
Follow-up to #13 for the 3 SHOULD-FIX review items.

## Summary
- remove the redundant `try/except Exception: raise` wrapper in `discover()` while keeping the staging-state atomicity comment
- clarify the retry contract in the `ModuleRegistry` docstring and add the thread-safety caveat
- add regression tests covering retry-after-failure and namespace collisions against pre-existing manual registrations

## Testing
- `.venv/bin/pytest tests/test_modules/test_registry.py`
