### PR TITLE
feat(session): add TTL, LRU eviction, max messages, thread-safety

### DIFF
--- a/src/safe_agent/core/session.py
+++ b/src/safe_agent/core/session.py
@@ -69,8 +69,19 @@ class SessionManager:
         else:
             self.session_ttl = timedelta(seconds=session_ttl)
 
+        # Validate TTL is non-negative
+        if self.session_ttl.total_seconds() < 0:
+            raise ValueError("session_ttl must be non-negative")
+
+        # Apply defaults
         self.max_sessions = max_sessions if max_sessions is not None else 1000
         self.max_messages = max_messages if max_messages is not None else 1000
+
+        # Validate limits are positive
+        if self.max_sessions <= 0:
+            raise ValueError("max_sessions must be positive")
+        if self.max_messages <= 0:
+            raise ValueError("max_messages must be positive")
 
         # OrderedDict maintains access order for LRU eviction
         self._sessions: OrderedDict[str, Session] = OrderedDict()
@@ -128,10 +139,13 @@ class SessionManager:
     def close(self, session_id: str) -> None:
         """Remove a session from active tracking if present.
 
+        Note: This triggers lazy cleanup of expired sessions as a side effect.
+
         Args:
             session_id: The unique identifier of the session to close.
         """
         with self._lock:
+            self._cleanup_expired()
             self._sessions.pop(session_id, None)
 
     def list_active(self) -> list[str]:
@@ -165,19 +179,22 @@ class SessionManager:
             session.messages.append(message)
 
             if trim and len(session.messages) > self.max_messages:
-                # Trim oldest messages (keep most recent max_messages)
+                # Trim oldest messages in-place (keep most recent max_messages)
                 excess = len(session.messages) - self.max_messages
-                session.messages = session.messages[excess:]
+                del session.messages[:excess]
 
             return session
 
     def count(self) -> int:
         """Return the current number of active sessions.
 
+        Note: This triggers lazy cleanup of expired sessions first.
+
         Returns:
             Number of sessions currently being tracked.
         """
         with self._lock:
+            self._cleanup_expired()
             return len(self._sessions)
 
     def set_eviction_callback(self, callback: Callable[[Session], None] | None) -> None:

--- a/tests/test_core/test_session.py
+++ b/tests/test_core/test_session.py
@@ -2,7 +2,7 @@
 
 import threading
 import time
-from datetime import UTC, datetime, timedelta
+from datetime import timedelta
 from uuid import UUID
 
 from safe_agent.core import SessionManager
@@ -230,7 +230,9 @@ class TestMaxMessages:
 
         # Add 5 messages without trimming
         for i in range(5):
-            manager.add_message(session.id, {"role": "user", "content": str(i)}, trim=False)
+            manager.add_message(
+                session.id, {"role": "user", "content": str(i)}, trim=False
+            )
 
         # Should keep all
         assert len(session.messages) == 5
@@ -267,7 +269,7 @@ class TestEvictionCallback:
         manager.set_eviction_callback(lambda s: evicted.append(s.id))
 
         session1 = manager.create()
-        session2 = manager.create()  # Should evict session1
+        _ = manager.create()  # Evicts session1
 
         assert session1.id in evicted
 
@@ -277,8 +279,8 @@ class TestEvictionCallback:
         manager.set_eviction_callback(lambda s: evicted.append(s.id))
         manager.set_eviction_callback(None)  # Disable
 
-        session1 = manager.create()
-        session2 = manager.create()
+        manager.create()
+        manager.create()
 
         # Callback was disabled, should not have been called
         assert len(evicted) == 0
@@ -291,7 +293,7 @@ class TestEvictionCallback:
         manager.set_eviction_callback(bad_callback)
 
         session1 = manager.create()
-        session2 = manager.create()
+        _ = manager.create()
 
         # Session1 should still be evicted despite callback error
         assert manager.get(session1.id) is None
@@ -302,14 +304,16 @@ class TestThreadSafety:
 
     def test_concurrent_creates(self) -> None:
         manager = SessionManager(max_sessions=1000)
-        session_ids = []
+        session_ids_lock = threading.Lock()
+        session_ids: list[str] = []
         errors = []
 
         def create_sessions() -> None:
             try:
                 for _ in range(100):
                     session = manager.create()
-                    session_ids.append(session.id)
+                    with session_ids_lock:
+                        session_ids.append(session.id)
             except Exception as e:
                 errors.append(e)
 
@@ -336,7 +340,9 @@ class TestThreadSafety:
             except Exception as e:
                 errors.append(e)
 
-        threads = [threading.Thread(target=get_and_close, args=(i * 10,)) for i in range(10)]
+        threads = [
+            threading.Thread(target=get_and_close, args=(i * 10,)) for i in range(10)
+        ]
         for t in threads:
             t.start()
         for t in threads:
@@ -365,3 +371,78 @@ class TestThreadSafety:
         assert len(errors) == 0
         # Should have been trimmed to max_messages
         assert len(session.messages) <= 100
+
+
+class TestInputValidation:
+    """Tests for constructor input validation."""
+
+    def test_max_sessions_zero_raises(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError, match="max_sessions must be positive"):
+            SessionManager(max_sessions=0)
+
+    def test_max_sessions_negative_raises(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError, match="max_sessions must be positive"):
+            SessionManager(max_sessions=-1)
+
+    def test_max_messages_zero_raises(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError, match="max_messages must be positive"):
+            SessionManager(max_messages=0)
+
+    def test_max_messages_negative_raises(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError, match="max_messages must be positive"):
+            SessionManager(max_messages=-1)
+
+    def test_negative_ttl_raises(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError, match="session_ttl must be non-negative"):
+            SessionManager(session_ttl=-10)
+
+    def test_negative_timedelta_ttl_raises(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError, match="session_ttl must be non-negative"):
+            SessionManager(session_ttl=timedelta(seconds=-5))
+
+    def test_zero_ttl_allowed(self) -> None:
+        # Zero TTL is allowed (sessions expire immediately)
+        manager = SessionManager(session_ttl=0)
+        assert manager.session_ttl == timedelta(0)
+
+
+class TestCleanupConsistency:
+    """Tests for cleanup behavior across all methods."""
+
+    def test_count_triggers_cleanup(self) -> None:
+        manager = SessionManager(session_ttl=0.1)
+
+        manager.create()
+
+        # Wait for TTL
+        time.sleep(0.15)
+
+        # count() should trigger cleanup
+        assert manager.count() == 0
+
+    def test_close_triggers_cleanup(self) -> None:
+        manager = SessionManager(session_ttl=0.1)
+
+        session1 = manager.create()
+        _ = manager.create()
+
+        # Wait for TTL
+        time.sleep(0.15)
+
+        # close() should trigger cleanup
+        manager.close(session1.id)
+
+        # Both sessions should be gone (session1 closed, session2 expired)
+        assert manager.count() == 0


### PR DESCRIPTION
## Summary

Closes #26

This PR addresses the memory exhaustion vulnerability in `SessionManager` by adding:

- **Session TTL**: Configurable time-to-live (default 1 hour) after which idle sessions are automatically evicted
- **Max sessions with LRU eviction**: Maximum concurrent sessions (default 1000) with least-recently-used eviction when exceeded
- **Max messages per session**: Limit on message history (default 1000) with oldest-first trimming
- **Thread-safety**: All public methods protected by `RLock` for safe concurrent access
- **Lazy cleanup**: No background thread required — cleanup happens on access operations

## Changes

### `Session` model
- Added `last_accessed` timestamp field to track idle time

### `SessionManager`
- New constructor parameters: `session_ttl`, `max_sessions`, `max_messages`
- Internal storage changed to `OrderedDict` for LRU ordering
- Thread-safe operations using `threading.RLock`
- New methods: `add_message()`, `count()`, `set_eviction_callback()`
- Private cleanup methods: `_cleanup_expired()`, `_evict_lru()`, `_evict_session()`

## Tests

31 tests covering:
- Basic CRUD operations (create, get, close, list)
- TTL expiration and cleanup
- LRU eviction behavior
- Message trimming
- Eviction callbacks
- Thread-safety under concurrent load

## Breaking Changes

None — all new functionality is opt-in with sensible defaults. Existing code continues to work unchanged.

## Security Impact

Prevents DoS via memory exhaustion from abandoned sessions (P2 priority).