### PR TITLE
feat(ci): set minimum coverage threshold at 85%

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Run tests
-        run: pytest --cov=safe_agent --cov-report=term-missing
+        run: pytest --cov=safe_agent --cov-report=term-missing --cov-fail-under=85
 
       - name: Upload coverage
         if: matrix.python-version == '3.13'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,4 +144,4 @@ branch = true
 
 [tool.coverage.report]
 show_missing = true
-fail_under = 0
+fail_under = 85


### PR DESCRIPTION
## Problem

pyproject.toml had `fail_under = 0`, meaning test coverage could silently drop to 0% without CI failing.

## Changes

- Set `fail_under = 85` in `[tool.coverage.report]` in pyproject.toml
- Added `--cov-fail-under=85` to pytest command in ci.yml

## Context

- Current coverage: **94%**
- Threshold: **85%** (provides buffer for minor drops)
- Priority: P1 — Prevents silent coverage regression

Fixes #24