### PR TITLE
fix: move chromadb and tiktoken to optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ pip install -e ".[dev]"
 pytest
 ```
 
+> **Note:** The core package is lightweight (~5MB). If you need RAG capabilities
+> with vector storage, install with `pip install -e ".[rag,dev]"` instead. This
+> adds `chromadb` and `tiktoken` (~500MB+ with dependencies).
+
 ## Development
 
 **Requires:** Python 3.13+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,16 @@ classifiers = [
 ]
 dependencies = [
     "pydantic>=2.0",
-    "chromadb>=0.5.0",
-    "tiktoken>=0.7.0",
     "httpx>=0.27.0",
     "aiofiles>=24.1.0",
     "gitpython>=3.1.0",
 ]
 
 [project.optional-dependencies]
+rag = [
+    "chromadb>=0.5.0",
+    "tiktoken>=0.7.0",
+]
 dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",


### PR DESCRIPTION
## Summary

- Moved `chromadb` and `tiktoken` from core dependencies to `[project.optional-dependencies].rag`
- Reduces core install footprint from ~500MB+ to ~5MB
- Users who need RAG capabilities can install with `pip install safe-agent[rag]`
- Updated README.md quick-start with note about optional RAG dependencies

## Testing

- All existing tests pass (185 tests)
- Lint, format, and type checks pass
- No code changes required (packages were not imported anywhere)

Closes #27