### PR TITLE
feat: add tool_call_id for provenance tracking

### DIFF
--- a/src/safe_agent/core/audit.py
+++ b/src/safe_agent/core/audit.py
@@ -61,6 +61,9 @@ class AuditEntry(BaseModel):
         session_id: Identifier for the session that triggered the tool call.
         timestamp: ISO-8601 UTC timestamp of the decision.
         tool_name: The fully-qualified tool name that was evaluated.
+        tool_call_id: Optional unique identifier for the tool call, used for
+            provenance tracking when the LLM makes multiple identical calls.
+            Propagated from :class:`~safe_agent.core.llm.ToolCall.id`.
         params: Input parameters for the tool call, capped at
             ``_MAX_PARAM_BYTES`` (8 KB). Values exceeding the cap are replaced
             with ``{"__truncated__": True}``. Callers should also redact
@@ -78,6 +81,7 @@ class AuditEntry(BaseModel):
     session_id: str
     timestamp: str
     tool_name: str
+    tool_call_id: str | None = None
     params: dict[str, Any] = Field(default_factory=dict)
     resolved_conditions: dict[str, Any] = Field(default_factory=dict)
     decision: Decision

--- a/src/safe_agent/core/dispatcher.py
+++ b/src/safe_agent/core/dispatcher.py
@@ -112,6 +112,7 @@ class ToolDispatcher:
         tool_name: str,
         params: dict[str, Any],
         session_id: str,
+        tool_call_id: str | None = None,
     ) -> ToolResult[Any]:
         """Authorise and execute a tool call.
 
@@ -123,6 +124,9 @@ class ToolDispatcher:
             params: Raw input parameters for the tool.
             session_id: Non-empty identifier for the calling session, used in
                 audit logs.
+            tool_call_id: Optional unique identifier for the tool call, used
+                for provenance tracking when the LLM makes multiple identical
+                calls in one turn.
 
         Returns:
             A :class:`~safe_agent.modules.base.ToolResult`. On any failure
@@ -147,6 +151,7 @@ class ToolDispatcher:
                     session_id=session_id,
                     timestamp=timestamp,
                     tool_name=tool_name,
+                    tool_call_id=tool_call_id,
                     params=params,
                     resolved_conditions={},
                     decision=Decision.DENIED_IMPLICIT,
@@ -189,6 +194,7 @@ class ToolDispatcher:
                     session_id=session_id,
                     timestamp=timestamp,
                     tool_name=tool_name,
+                    tool_call_id=tool_call_id,
                     params=params,
                     resolved_conditions={},
                     decision=Decision.DENIED_IMPLICIT,
@@ -227,6 +233,7 @@ class ToolDispatcher:
                         session_id=session_id,
                         timestamp=timestamp,
                         tool_name=tool_name,
+                        tool_call_id=tool_call_id,
                         params=params,
                         resolved_conditions=resolved_conditions,
                         decision=Decision.DENIED_IMPLICIT,
@@ -243,6 +250,7 @@ class ToolDispatcher:
                     session_id=session_id,
                     timestamp=timestamp,
                     tool_name=tool_name,
+                    tool_call_id=tool_call_id,
                     params=params,
                     resolved_conditions=resolved_conditions,
                     decision=eval_result.decision,
@@ -288,6 +296,7 @@ class ToolDispatcher:
                     session_id=session_id,
                     timestamp=timestamp,
                     tool_name=tool_name,
+                    tool_call_id=tool_call_id,
                     params=params,
                     resolved_conditions=resolved_conditions,
                     decision=Decision.DENIED_IMPLICIT,
@@ -304,6 +313,7 @@ class ToolDispatcher:
                 session_id=session_id,
                 timestamp=timestamp,
                 tool_name=tool_name,
+                tool_call_id=tool_call_id,
                 params=params,
                 resolved_conditions=resolved_conditions,
                 decision=Decision.ALLOWED,

--- a/src/safe_agent/core/event_loop.py
+++ b/src/safe_agent/core/event_loop.py
@@ -133,18 +133,20 @@ class EventLoop:
                                 tool_call.name,
                                 tool_call.params,
                                 session.id,
+                                tool_call.id,
                             )
                             content = json.dumps(result.model_dump())
                         except Exception as exc:
                             content = json.dumps({"error": str(exc)})
 
-                        session.messages.append(
-                            {
-                                "role": "tool",
-                                "name": tool_call.name,
-                                "content": content,
-                            }
-                        )
+                        tool_msg: dict = {
+                            "role": "tool",
+                            "name": tool_call.name,
+                            "content": content,
+                        }
+                        if tool_call.id is not None:
+                            tool_msg["tool_call_id"] = tool_call.id
+                        session.messages.append(tool_msg)
 
                 turn_count += 1
                 if turn_count >= self._max_turns:

--- a/src/safe_agent/core/llm.py
+++ b/src/safe_agent/core/llm.py
@@ -51,10 +51,20 @@ def restore_tool_name(name: str) -> str:
 
 
 class ToolCall(BaseModel):
-    """Represents a model-requested tool invocation."""
+    """Represents a model-requested tool invocation.
+
+    Attributes:
+        name: The fully-qualified tool name (e.g. ``"fs:ReadFile"``).
+        params: Input parameters for the tool call.
+        id: Optional unique identifier for the tool call, used for provenance
+            tracking when the LLM makes multiple identical calls in one turn.
+            Most LLM APIs (OpenAI, Anthropic) include this field; it propagates
+            through the event loop, dispatcher, and audit log.
+    """
 
     name: str
     params: dict[str, Any]
+    id: str | None = None
 
 
 class LLMResponse(BaseModel):

--- a/tests/test_core/test_audit.py
+++ b/tests/test_core/test_audit.py
@@ -65,6 +65,28 @@ class TestAuditEntry:
         entry = _make_entry(matched_statements=[None, "SomePolicy"])
         assert entry.matched_statements == [None, "SomePolicy"]
 
+    def test_tool_call_id_defaults_to_none(self) -> None:
+        """tool_call_id should default to None when not provided."""
+        entry = _make_entry()
+        assert entry.tool_call_id is None
+
+    def test_tool_call_id_stored_when_provided(self) -> None:
+        """tool_call_id should be stored when explicitly provided."""
+        entry = _make_entry(tool_call_id="call-abc123")
+        assert entry.tool_call_id == "call-abc123"
+
+    def test_tool_call_id_in_json(self) -> None:
+        """tool_call_id should appear in JSON output when set."""
+        entry = _make_entry(tool_call_id="call-xyz")
+        parsed = json.loads(entry.model_dump_json())
+        assert parsed["tool_call_id"] == "call-xyz"
+
+    def test_tool_call_id_null_in_json_when_none(self) -> None:
+        """tool_call_id should be null in JSON when not set."""
+        entry = _make_entry()
+        parsed = json.loads(entry.model_dump_json())
+        assert parsed["tool_call_id"] is None
+
 
 class TestAuditLogger:
     """Tests for AuditLogger."""

--- a/tests/test_core/test_dispatcher.py
+++ b/tests/test_core/test_dispatcher.py
@@ -396,3 +396,47 @@ class TestToolDispatcher:
         assert result.error == "Dispatch failed"
         assert call_count == 1
         assert _audit(tmp_path).read_entries() == []
+
+    async def test_tool_call_id_propagates_to_audit_log(self, tmp_path: Path) -> None:
+        """tool_call_id must appear in audit entries for allowed calls."""
+        module = _make_module("fs", "fs:Read", "filesystem:Read", ["path"])
+        dispatcher = _make_dispatcher(module, _ALLOW_ALL, tmp_path)
+        result = await dispatcher.dispatch(
+            "fs:Read", {"path": "/etc/hosts"}, "s1", tool_call_id="call-abc123"
+        )
+        assert result.success is True
+        entries = _audit(tmp_path).read_entries()
+        # All entries should have the tool_call_id
+        for entry in entries:
+            assert entry.tool_call_id == "call-abc123"
+
+    async def test_tool_call_id_in_audit_for_denied(self, tmp_path: Path) -> None:
+        """tool_call_id must appear in audit entries for denied calls."""
+        module = _make_module("fs", "fs:Read", "filesystem:Read", ["path"])
+        dispatcher = _make_dispatcher(module, _DENY_ALL, tmp_path)
+        await dispatcher.dispatch(
+            "fs:Read", {"path": "/etc/hosts"}, "s1", tool_call_id="call-xyz"
+        )
+        entries = _audit(tmp_path).read_entries()
+        assert len(entries) == 1
+        assert entries[0].tool_call_id == "call-xyz"
+        assert entries[0].decision == Decision.DENIED_EXPLICIT
+
+    async def test_tool_call_id_in_audit_for_unknown_tool(self, tmp_path: Path) -> None:
+        """tool_call_id must appear in audit entries for unknown tool probes."""
+        module = _make_module("fs", "fs:Read", "filesystem:Read")
+        dispatcher = _make_dispatcher(module, _ALLOW_ALL, tmp_path)
+        await dispatcher.dispatch("ghost:Op", {}, "s1", tool_call_id="call-unknown")
+        entries = _audit(tmp_path).read_entries()
+        assert len(entries) == 1
+        assert entries[0].tool_call_id == "call-unknown"
+        assert entries[0].matched_statements == ["__unknown_tool__"]
+
+    async def test_tool_call_id_none_when_not_provided(self, tmp_path: Path) -> None:
+        """When tool_call_id is not provided, audit entries should have None."""
+        module = _make_module("fs", "fs:Read", "filesystem:Read", ["path"])
+        dispatcher = _make_dispatcher(module, _ALLOW_ALL, tmp_path)
+        await dispatcher.dispatch("fs:Read", {"path": "/etc/hosts"}, "s1")
+        entries = _audit(tmp_path).read_entries()
+        for entry in entries:
+            assert entry.tool_call_id is None

--- a/tests/test_core/test_event_loop.py
+++ b/tests/test_core/test_event_loop.py
@@ -17,15 +17,16 @@ from safe_agent.modules.registry import ModuleRegistry
 
 class _FakeDispatcher:
     def __init__(self) -> None:
-        self.calls: list[tuple[str, dict[str, Any], str]] = []
+        self.calls: list[tuple[str, dict[str, Any], str, str | None]] = []
 
     async def dispatch(
         self,
         tool_name: str,
         params: dict[str, Any],
         session_id: str,
+        tool_call_id: str | None = None,
     ) -> ToolResult[Any]:
-        self.calls.append((tool_name, params, session_id))
+        self.calls.append((tool_name, params, session_id, tool_call_id))
         return ToolResult(success=True, data={"echo": params})
 
 
@@ -35,8 +36,9 @@ class _FailingDispatcher(_FakeDispatcher):
         tool_name: str,
         params: dict[str, Any],
         session_id: str,
+        tool_call_id: str | None = None,
     ) -> ToolResult[Any]:
-        self.calls.append((tool_name, params, session_id))
+        self.calls.append((tool_name, params, session_id, tool_call_id))
         msg = f"boom for {tool_name}"
         raise RuntimeError(msg)
 
@@ -128,12 +130,12 @@ def test_tool_call_then_text(registry: ModuleRegistry) -> None:
     result = asyncio.run(event_loop.process_turn(session, "run tool"))
 
     assert result == "tool complete"
-    assert dispatcher.calls == [("demo:echo", {"value": 1}, "session-1")]
+    assert dispatcher.calls == [("demo:echo", {"value": 1}, "session-1", None)]
     assert session.messages[0] == {"role": "user", "content": "run tool"}
     assert session.messages[1] == {
         "role": "assistant",
         "content": None,
-        "tool_calls": [{"name": "demo:echo", "params": {"value": 1}}],
+        "tool_calls": [{"name": "demo:echo", "params": {"value": 1}, "id": None}],
     }
     assert session.messages[2]["role"] == "tool"
     assert session.messages[2]["name"] == "demo:echo"
@@ -163,7 +165,7 @@ def test_tool_dispatch_failure_appends_error_tool_message(
     result = asyncio.run(event_loop.process_turn(session, "run tool"))
 
     assert result == "tool failed cleanly"
-    assert dispatcher.calls == [("demo:echo", {"value": 1}, "session-1")]
+    assert dispatcher.calls == [("demo:echo", {"value": 1}, "session-1", None)]
     assert session.messages[2] == {
         "role": "tool",
         "name": "demo:echo",
@@ -313,7 +315,7 @@ def test_llm_tool_call_name_restored_before_dispatch(
 
     asyncio.run(event_loop.process_turn(session, "run tool"))
 
-    dispatched_name, _, _ = dispatcher.calls[0]
+    dispatched_name, _, _, _ = dispatcher.calls[0]
     assert dispatched_name == "demo:echo", (
         f"Expected canonical 'demo:echo' at dispatch, got '{dispatched_name}'"
     )
@@ -370,3 +372,86 @@ def test_sanitized_history_sent_to_llm_on_second_turn(
                 f"History tool_call name '{tc['name']}' "
                 "not sanitized on second LLM call"
             )
+
+
+# ---------------------------------------------------------------------------
+# Tool call ID provenance tests
+# ---------------------------------------------------------------------------
+
+
+def test_tool_call_id_propagates_to_dispatcher(registry: ModuleRegistry) -> None:
+    """ToolCall.id must flow through to the dispatcher."""
+    dispatcher = _FakeDispatcher()
+    llm = _FakeLLM(
+        [
+            LLMResponse(
+                tool_calls=[
+                    ToolCall(name="demo:echo", params={"value": 1}, id="call-abc123")
+                ]
+            ),
+            LLMResponse(content="done"),
+        ]
+    )
+    event_loop = EventLoop(dispatcher, llm, registry)
+    session = Session(id="session-1")
+
+    asyncio.run(event_loop.process_turn(session, "run tool"))
+
+    assert dispatcher.calls == [("demo:echo", {"value": 1}, "session-1", "call-abc123")]
+
+
+def test_tool_call_id_in_session_transcript(registry: ModuleRegistry) -> None:
+    """Tool result messages must include tool_call_id when present."""
+    dispatcher = _FakeDispatcher()
+    llm = _FakeLLM(
+        [
+            LLMResponse(
+                tool_calls=[
+                    ToolCall(name="demo:echo", params={"value": 1}, id="call-xyz")
+                ]
+            ),
+            LLMResponse(content="done"),
+        ]
+    )
+    event_loop = EventLoop(dispatcher, llm, registry)
+    session = Session(id="session-1")
+
+    asyncio.run(event_loop.process_turn(session, "run tool"))
+
+    # Assistant message with tool_calls
+    assistant_msg = session.messages[1]
+    assert assistant_msg["tool_calls"][0]["id"] == "call-xyz"
+
+    # Tool result message
+    tool_msg = session.messages[2]
+    assert tool_msg["tool_call_id"] == "call-xyz"
+
+
+def test_multiple_tool_calls_with_distinct_ids(registry: ModuleRegistry) -> None:
+    """Multiple tool calls in one turn must preserve distinct IDs."""
+    dispatcher = _FakeDispatcher()
+    llm = _FakeLLM(
+        [
+            LLMResponse(
+                tool_calls=[
+                    ToolCall(name="demo:echo", params={"n": 1}, id="call-a"),
+                    ToolCall(name="demo:echo", params={"n": 2}, id="call-b"),
+                ]
+            ),
+            LLMResponse(content="done"),
+        ]
+    )
+    event_loop = EventLoop(dispatcher, llm, registry)
+    session = Session(id="session-1")
+
+    asyncio.run(event_loop.process_turn(session, "run tools"))
+
+    # Dispatcher sees both calls with correct IDs
+    assert dispatcher.calls[0] == ("demo:echo", {"n": 1}, "session-1", "call-a")
+    assert dispatcher.calls[1] == ("demo:echo", {"n": 2}, "session-1", "call-b")
+
+    # Session transcript has both tool results with correct IDs
+    tool_msg_1 = session.messages[2]
+    assert tool_msg_1["tool_call_id"] == "call-a"
+    tool_msg_2 = session.messages[3]
+    assert tool_msg_2["tool_call_id"] == "call-b"


### PR DESCRIPTION
## Summary

Fixes #34

Add optional `id` field to `ToolCall` for tracking tool call identity when LLMs make multiple identical calls in one turn.

### Changes

- **ToolCall** (`src/safe_agent/core/llm.py`): Add optional `id: str | None = None` field
- **AuditEntry** (`src/safe_agent/core/audit.py`): Add optional `tool_call_id: str | None = None` field
- **ToolDispatcher.dispatch()`: Accept `tool_call_id` parameter, include in all audit entries
- **EventLoop**: Pass `tool_call.id` to dispatcher, include `tool_call_id` in tool response messages

### Why

Most LLM APIs (OpenAI, Anthropic) include a unique identifier for each tool call. Without this field, if an LLM requests two identical tool calls in one turn, they are indistinguishable in the audit log and session transcript.

### Testing

- 290 tests passing (11 new tests for tool_call_id feature)
- Test coverage for:
  - ToolCall.id propagation through event loop to dispatcher
  - tool_call_id in session transcript tool messages
  - Multiple tool calls with distinct IDs preserved correctly
  - tool_call_id in AuditEntry serialization
  - tool_call_id in audit log for allowed/denied/unknown-tool cases

## Checklist

- [x] Ran `ruff check` + `ruff format` locally
- [x] All tests pass