### PR TITLE
feat(iam): add Bool condition operator to policy evaluator

### DIFF
--- a/src/safe_agent/iam/evaluator.py
+++ b/src/safe_agent/iam/evaluator.py
@@ -33,6 +33,10 @@ _STRING_OPS = {
     "StringNotLike",
 }
 
+_BOOL_OPS = {
+    "Bool",
+}
+
 
 def _match_string_op(operator: str, ctx_val: str, condition_val: str) -> bool:
     """Evaluate a single string condition comparison.
@@ -88,6 +92,23 @@ def _match_numeric_op(operator: str, ctx_val: float, condition_val: float) -> bo
     raise ValueError(f"Unknown numeric operator: {operator!r}")  # pragma: no cover
 
 
+def _match_bool_op(ctx_val: Any, condition_val: Any) -> bool:
+    """Evaluate a boolean condition comparison.
+
+    Both values are converted to lowercase strings and compared for equality.
+    This supports common truthy/falsy representations like "true", "True",
+    "false", "False", as well as boolean ``True``/``False`` values.
+
+    Args:
+        ctx_val: The actual value from the request context.
+        condition_val: The expected boolean value from the condition block.
+
+    Returns:
+        ``True`` if both values normalize to the same boolean string.
+    """
+    return str(ctx_val).lower() == str(condition_val).lower()
+
+
 def _evaluate_condition_block(
     condition: dict[str, Any],
     context: dict[str, Any],
@@ -136,6 +157,11 @@ def _evaluate_condition_block(
                     except (TypeError, ValueError):
                         return False
                     if _match_numeric_op(operator, num_ctx, num_v):
+                        matched_any = True
+                        break
+            elif operator in _BOOL_OPS:
+                for v in values_list:
+                    if _match_bool_op(ctx_val, v):
                         matched_any = True
                         break
             else:

--- a/tests/test_iam/test_evaluator.py
+++ b/tests/test_iam/test_evaluator.py
@@ -524,6 +524,199 @@ class TestConditions:
         )
 
 
+class TestBoolCondition:
+    """Verify Bool condition operator behavior."""
+
+    def test_bool_true_satisfied(self):
+        store = make_store(
+            {
+                "Version": "2025-01",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["agent:*"],
+                        "Resource": ["*"],
+                        "Condition": {"Bool": {"filesystem:IsDirectory": "true"}},
+                    }
+                ],
+            }
+        )
+        ev = PolicyEvaluator(store)
+        assert (
+            ev.evaluate(
+                make_request("agent:Read", "*", **{"filesystem:IsDirectory": "true"})
+            ).decision
+            == Decision.ALLOWED
+        )
+
+    def test_bool_false_satisfied(self):
+        store = make_store(
+            {
+                "Version": "2025-01",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["agent:*"],
+                        "Resource": ["*"],
+                        "Condition": {"Bool": {"filesystem:IsDirectory": "false"}},
+                    }
+                ],
+            }
+        )
+        ev = PolicyEvaluator(store)
+        assert (
+            ev.evaluate(
+                make_request("agent:Read", "*", **{"filesystem:IsDirectory": "false"})
+            ).decision
+            == Decision.ALLOWED
+        )
+
+    def test_bool_case_insensitive(self):
+        store = make_store(
+            {
+                "Version": "2025-01",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["agent:*"],
+                        "Resource": ["*"],
+                        "Condition": {"Bool": {"flag": "True"}},
+                    }
+                ],
+            }
+        )
+        ev = PolicyEvaluator(store)
+        # Context value with different case
+        assert (
+            ev.evaluate(make_request("agent:Run", "*", flag="TRUE")).decision
+            == Decision.ALLOWED
+        )
+        assert (
+            ev.evaluate(make_request("agent:Run", "*", flag="true")).decision
+            == Decision.ALLOWED
+        )
+        assert (
+            ev.evaluate(make_request("agent:Run", "*", flag="True")).decision
+            == Decision.ALLOWED
+        )
+
+    def test_bool_python_bool_values(self):
+        store = make_store(
+            {
+                "Version": "2025-01",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["agent:*"],
+                        "Resource": ["*"],
+                        "Condition": {"Bool": {"flag": True}},
+                    }
+                ],
+            }
+        )
+        ev = PolicyEvaluator(store)
+        # Python bool values should work
+        assert (
+            ev.evaluate(make_request("agent:Run", "*", flag=True)).decision
+            == Decision.ALLOWED
+        )
+        assert (
+            ev.evaluate(make_request("agent:Run", "*", flag=False)).decision
+            == Decision.DENIED_IMPLICIT
+        )
+
+    def test_bool_not_satisfied(self):
+        store = make_store(
+            {
+                "Version": "2025-01",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["agent:*"],
+                        "Resource": ["*"],
+                        "Condition": {"Bool": {"flag": "true"}},
+                    }
+                ],
+            }
+        )
+        ev = PolicyEvaluator(store)
+        assert (
+            ev.evaluate(make_request("agent:Run", "*", flag="false")).decision
+            == Decision.DENIED_IMPLICIT
+        )
+
+    def test_bool_missing_key(self):
+        store = make_store(
+            {
+                "Version": "2025-01",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["agent:*"],
+                        "Resource": ["*"],
+                        "Condition": {"Bool": {"flag": "true"}},
+                    }
+                ],
+            }
+        )
+        ev = PolicyEvaluator(store)
+        # No flag in context
+        assert (
+            ev.evaluate(make_request("agent:Run", "*")).decision
+            == Decision.DENIED_IMPLICIT
+        )
+
+    def test_bool_multiple_values_ored(self):
+        store = make_store(
+            {
+                "Version": "2025-01",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["agent:*"],
+                        "Resource": ["*"],
+                        "Condition": {"Bool": {"flag": ["true", "false"]}},
+                    }
+                ],
+            }
+        )
+        ev = PolicyEvaluator(store)
+        # Either value should match
+        assert (
+            ev.evaluate(make_request("agent:Run", "*", flag="true")).decision
+            == Decision.ALLOWED
+        )
+        assert (
+            ev.evaluate(make_request("agent:Run", "*", flag="false")).decision
+            == Decision.ALLOWED
+        )
+
+    def test_bool_non_boolean_value(self):
+        """Bool operator compares stringified values, so non-bools work too."""
+        store = make_store(
+            {
+                "Version": "2025-01",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["agent:*"],
+                        "Resource": ["*"],
+                        "Condition": {"Bool": {"status": "yes"}},
+                    }
+                ],
+            }
+        )
+        ev = PolicyEvaluator(store)
+        assert (
+            ev.evaluate(make_request("agent:Run", "*", status="yes")).decision
+            == Decision.ALLOWED
+        )
+        assert (
+            ev.evaluate(make_request("agent:Run", "*", status="no")).decision
+            == Decision.DENIED_IMPLICIT
+        )
+
+
 class TestMatchedStatementsInResult:
     """Verify the matched_statements field in AuthorizationResult."""
 


### PR DESCRIPTION
## Summary

Adds support for Bool condition operator in IAM-style policy evaluation.

Closes #33

## Problem

The IAM-style policy evaluator supports String and Numeric condition operators but lacks a Bool operator. This is a common operator in AWS IAM policies. Currently, boolean conditions like `filesystem:IsDirectory` must use StringEquals with "true" / "false" string values, which is unintuitive.

## Solution

Add Bool operator support to `_evaluate_condition_block()` in `src/safe_agent/iam/evaluator.py`.

**Implementation:**
- Add `_BOOL_OPS` set for operator recognition
- Add `_match_bool_op()` helper that performs case-insensitive string comparison
- Supports both string values ("true"/"false") and Python bool values (`True`/`False`)
- Follows existing pattern for OR across multiple values

## Usage Example

```json
{
  "Condition": {
    "Bool": {
      "filesystem:IsDirectory": "true"
    }
  }
}
```

## Tests

Added 8 comprehensive tests:
- Bool true satisfied
- Bool false satisfied  
- Case-insensitive matching (TRUE/True/true)
- Python bool values (`True`/`False`)
- Not satisfied case
- Missing key denies
- Multiple values ORed
- Non-boolean values work (string comparison)

All 298 tests passing.