### PR TITLE
fix(iam): guard against inf/nan in numeric condition evaluation

### DIFF
--- a/src/safe_agent/iam/evaluator.py
+++ b/src/safe_agent/iam/evaluator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import fnmatch
+import math
 from typing import Any
 
 from safe_agent.iam.models import (
@@ -12,6 +13,26 @@ from safe_agent.iam.models import (
     Statement,
 )
 from safe_agent.iam.policy import PolicyStore
+
+
+def _safe_float(value: Any) -> float | None:
+    """Safely convert a value to float, rejecting inf and nan.
+
+    Args:
+        value: The value to convert (typically a string or number).
+
+    Returns:
+        The float value if valid and finite, or ``None`` if conversion fails
+        or the result is inf/nan.
+    """
+    try:
+        f = float(value)
+        if math.isinf(f) or math.isnan(f):
+            return None
+        return f
+    except (ValueError, TypeError):
+        return None
+
 
 # ---------------------------------------------------------------------------
 # Condition operator helpers
@@ -147,14 +168,12 @@ def _evaluate_condition_block(
                         matched_any = True
                         break
             elif operator in _NUMERIC_OPS:
-                try:
-                    num_ctx = float(ctx_val)
-                except (TypeError, ValueError):
+                num_ctx = _safe_float(ctx_val)
+                if num_ctx is None:
                     return False
                 for v in values_list:
-                    try:
-                        num_v = float(v)
-                    except (TypeError, ValueError):
+                    num_v = _safe_float(v)
+                    if num_v is None:
                         return False
                     if _match_numeric_op(operator, num_ctx, num_v):
                         matched_any = True

--- a/tests/test_iam/test_evaluator.py
+++ b/tests/test_iam/test_evaluator.py
@@ -731,3 +731,162 @@ class TestMatchedStatementsInResult:
         result = ev.evaluate(make_request("agent:Delete", "arn:tool:bash"))
         assert result.decision == Decision.DENIED_IMPLICIT
         assert result.matched_statements == []
+
+
+class TestInfNanGuard:
+    """Verify that inf and nan values are rejected in numeric conditions."""
+
+    def test_context_value_inf_denied(self):
+        """Inf in context should deny, preventing NumericLessThan bypass."""
+        store = make_store(
+            {
+                "Version": "2025-01",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["agent:*"],
+                        "Resource": ["*"],
+                        "Condition": {"NumericLessThan": {"count": 100}},
+                    }
+                ],
+            }
+        )
+        ev = PolicyEvaluator(store)
+        # "inf" would bypass NumericLessThan (anything < inf is True)
+        result = ev.evaluate(make_request("agent:Run", "*", count="inf"))
+        assert result.decision == Decision.DENIED_IMPLICIT
+
+    def test_context_value_infinity_denied(self):
+        """'infinity' string should also be denied."""
+        store = make_store(
+            {
+                "Version": "2025-01",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["agent:*"],
+                        "Resource": ["*"],
+                        "Condition": {"NumericLessThan": {"count": 100}},
+                    }
+                ],
+            }
+        )
+        ev = PolicyEvaluator(store)
+        result = ev.evaluate(make_request("agent:Run", "*", count="infinity"))
+        assert result.decision == Decision.DENIED_IMPLICIT
+
+    def test_context_value_nan_denied(self):
+        """Nan in context should deny (nan comparisons are always False)."""
+        store = make_store(
+            {
+                "Version": "2025-01",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["agent:*"],
+                        "Resource": ["*"],
+                        "Condition": {"NumericEquals": {"count": 42}},
+                    }
+                ],
+            }
+        )
+        ev = PolicyEvaluator(store)
+        result = ev.evaluate(make_request("agent:Run", "*", count="nan"))
+        assert result.decision == Decision.DENIED_IMPLICIT
+
+    def test_condition_value_inf_denied(self):
+        """Inf in condition value should also deny."""
+        store = make_store(
+            {
+                "Version": "2025-01",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["agent:*"],
+                        "Resource": ["*"],
+                        "Condition": {"NumericGreaterThan": {"score": "inf"}},
+                    }
+                ],
+            }
+        )
+        ev = PolicyEvaluator(store)
+        # No finite number is > inf, but we should reject before comparison
+        result = ev.evaluate(make_request("agent:Run", "*", score=1000))
+        assert result.decision == Decision.DENIED_IMPLICIT
+
+    def test_condition_value_nan_denied(self):
+        """Nan in condition value should deny."""
+        store = make_store(
+            {
+                "Version": "2025-01",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["agent:*"],
+                        "Resource": ["*"],
+                        "Condition": {"NumericEquals": {"count": "nan"}},
+                    }
+                ],
+            }
+        )
+        ev = PolicyEvaluator(store)
+        result = ev.evaluate(make_request("agent:Run", "*", count=42))
+        assert result.decision == Decision.DENIED_IMPLICIT
+
+    def test_negative_inf_denied(self):
+        """Negative infinity should also be rejected."""
+        store = make_store(
+            {
+                "Version": "2025-01",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["agent:*"],
+                        "Resource": ["*"],
+                        "Condition": {"NumericGreaterThan": {"count": -1000}},
+                    }
+                ],
+            }
+        )
+        ev = PolicyEvaluator(store)
+        result = ev.evaluate(make_request("agent:Run", "*", count="-inf"))
+        assert result.decision == Decision.DENIED_IMPLICIT
+
+    def test_valid_float_still_works(self):
+        """Normal float values should still work after inf/nan guard."""
+        store = make_store(
+            {
+                "Version": "2025-01",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["agent:*"],
+                        "Resource": ["*"],
+                        "Condition": {"NumericLessThan": {"count": 100}},
+                    }
+                ],
+            }
+        )
+        ev = PolicyEvaluator(store)
+        # String representation of a valid float
+        result = ev.evaluate(make_request("agent:Run", "*", count="50.5"))
+        assert result.decision == Decision.ALLOWED
+
+    def test_valid_int_still_works(self):
+        """Integer values should still work."""
+        store = make_store(
+            {
+                "Version": "2025-01",
+                "Statement": [
+                    {
+                        "Effect": "Allow",
+                        "Action": ["agent:*"],
+                        "Resource": ["*"],
+                        "Condition": {"NumericEquals": {"count": 42}},
+                    }
+                ],
+            }
+        )
+        ev = PolicyEvaluator(store)
+        result = ev.evaluate(make_request("agent:Run", "*", count=42))
+        assert result.decision == Decision.ALLOWED


### PR DESCRIPTION
## Summary

- Adds `_safe_float()` helper that rejects `inf` and `nan` values
- Uses `_safe_float()` in `_evaluate_condition_block()` for numeric operators
- Prevents bypass of `NumericLessThan` conditions via `float(inf)`
- Returns `None` for inf/nan, causing the condition to fail (deny-by-default)
- Adds 8 tests covering inf/nan in both context and condition values

## Security Issue

The policy evaluator used `float()` for numeric condition comparisons. `float("inf")` was accepted as a valid numeric value, which could be used to bypass `NumericLessThan` conditions (since every finite number is less than infinity). `float("nan")` comparisons are always `False`, which is safe (defaults to deny), but is an unusual edge case.

## Fix

Before any numeric comparison, values are now validated via `_safe_float()`:
- Returns `None` if the value is `inf`, `-inf`, or `nan`
- Returns `None` if the value cannot be converted to float
- The condition fails (returns `False`) when either operand is `None`

## Testing

- All 42 existing tests pass
- 8 new tests specifically for inf/nan guard behavior

Closes #36