### PR TITLE
feat(iam): cache get_all_statements() on frozen PolicyStore

### DIFF
--- a/src/safe_agent/iam/policy.py
+++ b/src/safe_agent/iam/policy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import cast
 
 from pydantic import ValidationError
 
@@ -29,6 +30,7 @@ class PolicyStore:
         """Initialise an empty, mutable policy store."""
         self._policies: list[Policy] = []
         self._frozen: bool = False
+        self._cached_statements: list[Statement] | None = None
 
     def load(self, directory: Path) -> None:
         """Load all ``.json`` policy files from *directory*.
@@ -89,20 +91,31 @@ class PolicyStore:
         self._policies.append(policy)
 
     def freeze(self) -> None:
-        """Make the store immutable.
+        """Make the store immutable and cache statements for fast access.
 
         After calling :meth:`freeze`, any call to :meth:`add_policy` or
         :meth:`load` will raise a :class:`RuntimeError`.
         """
+        # Build cache before setting flag to avoid race condition
+        self._cached_statements = [s for p in self._policies for s in p.statements]
         self._frozen = True
 
     def get_all_statements(self) -> list[Statement]:
         """Return all statements across all loaded policies.
 
+        Once the store is frozen, this returns a cached list for performance.
+        Before freezing, the list is rebuilt on each call.
+
+        Note:
+            After freeze, the returned list must not be modified by the caller.
+
         Returns:
             A flat list of :class:`~safe_agent.iam.models.Statement` objects
             in the order they were added.
         """
+        if self._frozen:
+            # Cache is populated by freeze() before _frozen is set
+            return cast(list[Statement], self._cached_statements)
         statements: list[Statement] = []
         for policy in self._policies:
             statements.extend(policy.statements)

--- a/tests/test_iam/test_policy.py
+++ b/tests/test_iam/test_policy.py
@@ -150,6 +150,34 @@ class TestPolicyStoreFreeze:
         store.freeze()
         assert len(store.get_all_statements()) == 1
 
+    def test_cached_statements_returned_after_freeze(self):
+        """Verify that get_all_statements returns the cached list after freeze."""
+        policy = Policy.model_validate(VALID_POLICY)
+        store = PolicyStore()
+        store.add_policy(policy)
+        store.freeze()
+        first = store.get_all_statements()
+        second = store.get_all_statements()
+        assert first is second  # same object, not a copy
+
+    def test_freeze_empty_store_returns_empty_list(self):
+        """Freezing an empty store should return empty list from cache."""
+        store = PolicyStore()
+        store.freeze()
+        assert store.get_all_statements() == []
+
+    def test_double_freeze_preserves_cache(self):
+        """Double freeze should still return valid cached statements."""
+        policy = Policy.model_validate(VALID_POLICY)
+        store = PolicyStore()
+        store.add_policy(policy)
+        store.freeze()
+        first = store.get_all_statements()
+        store.freeze()  # second freeze rebuilds cache
+        second = store.get_all_statements()
+        # Cache may be rebuilt on second freeze, but contents must match
+        assert first == second
+
 
 class TestGetAllStatements:
     """Tests for PolicyStore.get_all_statements()."""
@@ -194,3 +222,13 @@ class TestGetAllStatements:
         stmts = store.get_all_statements()
         assert stmts[0].sid == "First"
         assert stmts[1].sid == "Second"
+
+    def test_returns_new_list_before_freeze(self):
+        """Before freeze, each call rebuilds the list (not cached)."""
+        policy = Policy.model_validate(VALID_POLICY)
+        store = PolicyStore()
+        store.add_policy(policy)
+        first = store.get_all_statements()
+        second = store.get_all_statements()
+        assert first is not second  # different objects
+        assert first == second  # but same contents


### PR DESCRIPTION
## Problem

PolicyStore.get_all_statements() rebuilds the flat statement list on every call by iterating all policies and collecting their statements into a new list. Since the store is frozen after initialization, this work is redundant after the first call.

## Solution

Cache the result after freeze() is called:
- Add _cached_statements attribute initialized to None
- freeze() builds cache BEFORE setting _frozen flag (avoids race condition)
- get_all_statements() returns cached list when frozen, rebuilds otherwise
- Document that returned list must not be modified by caller

This improves performance for high-throughput scenarios where every tool call triggers policy evaluation.

## Tests

- test_cached_statements_returned_after_freeze: verifies same object returned on repeated calls
- test_returns_new_list_before_freeze: verifies uncached behavior before freeze
- test_freeze_empty_store_returns_empty_list: edge case for empty store
- test_double_freeze_preserves_cache: verifies double freeze behavior
- All tests passing

Closes #35