### PR TITLE
feat(filesystem): add max_read_size limit for OOM defense

### DIFF
--- a/src/safe_agent/modules/filesystem.py
+++ b/src/safe_agent/modules/filesystem.py
@@ -233,6 +233,11 @@ class FilesystemModule(BaseModule):
         if path.is_dir():
             return ToolResult(success=False, error="Path is a directory")
 
+        # Note: TOCTOU race between stat() and read() — file could grow in the
+        # window. This is acceptable because: (1) the limit prevents unbounded
+        # allocation, just not exact enforcement, and (2) Python's read() will
+        # still be bounded by available memory; the limit provides defense-in-depth
+        # rather than a hard guarantee.
         file_size = path.stat().st_size
         if file_size > self.max_read_size:
             return ToolResult(

--- a/tests/test_modules/test_filesystem.py
+++ b/tests/test_modules/test_filesystem.py
@@ -328,10 +328,14 @@ class TestFilesystemModule:
         }
 
     async def test_read_file_accepts_exact_limit(self, tmp_path: Path) -> None:
-        """read_file should accept files exactly at max_read_size boundary."""
+        """read_file should accept files exactly at max_read_size boundary.
+
+        Note: This test uses ASCII content where byte count equals character count.
+        For UTF-8 content with multi-byte characters, the byte size would differ.
+        """
         limit = 100
         module = FilesystemModule(tmp_path, max_read_size=limit)
-        content = "x" * 100  # Exactly at limit
+        content = "x" * 100  # Exactly at limit (100 bytes for ASCII)
         (tmp_path / "exact_limit.txt").write_text(content, encoding="utf-8")
 
         result = await module.execute(


### PR DESCRIPTION
## Summary

Adds `max_read_size` parameter to `FilesystemModule` to prevent memory exhaustion from reading large files.

- Default: 10MB (matching `max_write_size`)
- Defense-in-depth: complements policy-level `filesystem:FileSize` guards
- Mirrors existing write limit pattern for consistency

## Changes

- Add `max_read_size` param to `__init__` with validation
- Check file size before reading in `_read_file()`
- Reject reads exceeding limit with clear error message
- Add 4 new tests (over-limit, under-limit, exact-limit, invalid param)

## Testing

```
316 tests passed
ruff check ✓
ruff format ✓
```

Closes #60