### PR TITLE
feat(filesystem): add max_list_entries to prevent resource exhaustion

### DIFF
--- a/src/safe_agent/modules/filesystem.py
+++ b/src/safe_agent/modules/filesystem.py
@@ -302,6 +302,11 @@ class FilesystemModule(BaseModule):
 
         Results are capped at max_list_entries to prevent resource exhaustion.
         If truncated, the result includes truncated=true and a warning.
+
+        Note: Results are sorted after truncation. When truncated, the returned
+        subset is non-deterministic (depends on filesystem iteration order).
+        This is acceptable for the resource-exhaustion use case; callers needing
+        deterministic results should use a more specific pattern or pagination.
         """
         path = self._resolve_path(str(params["path"]))
         recursive = bool(params.get("recursive", False))

--- a/tests/test_modules/test_filesystem.py
+++ b/tests/test_modules/test_filesystem.py
@@ -423,6 +423,21 @@ class TestFilesystemModule:
         assert len(result.data["entries"]) == 5
         assert "truncated" not in result.data
 
+    async def test_list_directory_accepts_exact_limit(self, tmp_path: Path) -> None:
+        """list_directory should accept exactly max_list_entries entries."""
+        limit = 5
+        module = FilesystemModule(tmp_path, max_list_entries=limit)
+
+        # Create exactly the limit number of entries
+        for i in range(limit):
+            (tmp_path / f"file{i}.txt").write_text(f"content{i}", encoding="utf-8")
+
+        result = await module.execute("filesystem:list_directory", {"path": "."})
+
+        assert result.success is True
+        assert len(result.data["entries"]) == limit
+        assert "truncated" not in result.data
+
     async def test_list_directory_truncates_recursive(self, tmp_path: Path) -> None:
         """list_directory should truncate recursive listings too."""
         small_limit = 3


### PR DESCRIPTION
## Summary

- Adds `max_list_entries` parameter to `FilesystemModule` (default: 1000)
- Truncates directory listings at the limit and includes `truncated: true` metadata
- Includes warning message explaining truncation and suggesting alternatives
- Validates `max_list_entries` must be positive (like existing size limits)

## Problem

`_list_directory` with `recursive=True` and a broad glob pattern (e.g., `*`) could return millions of entries from a large directory tree, consuming memory and producing a massive tool result sent back to the LLM.

## Solution

Cap results at `max_list_entries` and indicate truncation in the response:

```python
result_data = {
    "entries": [...],  # capped at max_list_entries
    "truncated": True,
    "warning": "Results truncated at 1000 entries. Use a more specific pattern or non-recursive listing."
}
```

## Testing

- 6 new tests for truncation behavior and validation
- All 31 filesystem tests passing
- All 228 total tests passing

Closes #64