### PR TITLE
fix(iam): return immutable tuple from PolicyStore.get_all_statements after freeze

### DIFF
--- a/src/safe_agent/iam/policy.py
+++ b/src/safe_agent/iam/policy.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Sequence
 from pathlib import Path
 from typing import cast
 
@@ -30,7 +31,7 @@ class PolicyStore:
         """Initialise an empty, mutable policy store."""
         self._policies: list[Policy] = []
         self._frozen: bool = False
-        self._cached_statements: list[Statement] | None = None
+        self._cached_statements: tuple[Statement, ...] | None = None
 
     def load(self, directory: Path) -> None:
         """Load all ``.json`` policy files from *directory*.
@@ -103,27 +104,31 @@ class PolicyStore:
 
         After calling :meth:`freeze`, any call to :meth:`add_policy` or
         :meth:`load` will raise a :class:`RuntimeError`.
+
+        The cached statements are stored as an immutable tuple to enforce
+        the frozen state guarantee — callers cannot mutate the returned
+        sequence and corrupt the policy store's internal state.
         """
-        # Build cache before setting flag to avoid race condition
-        self._cached_statements = [s for p in self._policies for s in p.statements]
+        # Build cache as immutable tuple before setting flag to avoid race condition
+        self._cached_statements = tuple(s for p in self._policies for s in p.statements)
         self._frozen = True
 
-    def get_all_statements(self) -> list[Statement]:
+    def get_all_statements(self) -> Sequence[Statement]:
         """Return all statements across all loaded policies.
 
-        Once the store is frozen, this returns a cached list for performance.
+        Once the store is frozen, this returns a cached tuple for performance.
         Before freezing, the list is rebuilt on each call.
 
-        Note:
-            After freeze, the returned list must not be modified by the caller.
+        The returned sequence is immutable after freeze — callers cannot
+        modify the cached statements.
 
         Returns:
-            A flat list of :class:`~safe_agent.iam.models.Statement` objects
+            A flat sequence of :class:`~safe_agent.iam.models.Statement` objects
             in the order they were added.
         """
         if self._frozen:
             # Cache is populated by freeze() before _frozen is set
-            return cast(list[Statement], self._cached_statements)
+            return cast(tuple[Statement, ...], self._cached_statements)
         statements: list[Statement] = []
         for policy in self._policies:
             statements.extend(policy.statements)

--- a/tests/test_iam/test_policy.py
+++ b/tests/test_iam/test_policy.py
@@ -215,7 +215,7 @@ class TestPolicyStoreFreeze:
         assert len(store.get_all_statements()) == 1
 
     def test_cached_statements_returned_after_freeze(self):
-        """Verify that get_all_statements returns the cached list after freeze."""
+        """Verify that get_all_statements returns the cached tuple after freeze."""
         policy = Policy.model_validate(VALID_POLICY)
         store = PolicyStore()
         store.add_policy(policy)
@@ -224,11 +224,23 @@ class TestPolicyStoreFreeze:
         second = store.get_all_statements()
         assert first is second  # same object, not a copy
 
-    def test_freeze_empty_store_returns_empty_list(self):
-        """Freezing an empty store should return empty list from cache."""
+    def test_frozen_statements_are_immutable(self):
+        """After freeze, returned statements cannot be mutated."""
+        policy = Policy.model_validate(VALID_POLICY)
+        store = PolicyStore()
+        store.add_policy(policy)
+        store.freeze()
+        stmts = store.get_all_statements()
+        # Tuple is immutable — it doesn't have append/clear/etc methods
+        assert isinstance(stmts, tuple)
+        assert not hasattr(stmts, "append")  # no mutation methods available
+
+    def test_freeze_empty_store_returns_empty_tuple(self):
+        """Freezing an empty store should return empty tuple from cache."""
         store = PolicyStore()
         store.freeze()
-        assert store.get_all_statements() == []
+        assert store.get_all_statements() == ()
+        assert len(store.get_all_statements()) == 0
 
     def test_double_freeze_preserves_cache(self):
         """Double freeze should still return valid cached statements."""


### PR DESCRIPTION
## Summary

Fixes #63 — Frozen PolicyStore returns mutable cached statement list

### Problem
After `freeze()`, `get_all_statements()` returned the same cached list object directly. A buggy caller could mutate it (e.g., `.append()`, `.clear()`) and silently corrupt the policy store's frozen state — undermining the immutability guarantee.

### Solution
- Convert `_cached_statements` to `tuple` on `freeze()` for immutability
- Change return type from `list[Statement]` to `Sequence[Statement]`
- Add test verifying frozen statements cannot be mutated

### Breaking Change ⚠️

The return type change from `list[Statement]` to `Sequence[Statement]` may cause type-checker errors in downstream code that annotated variables as `list[Statement]`. This is intentional — it surfaces any callers that might have been mutating the return value. If this project has external consumers, this should be noted in release notes.

### Testing
- All 327 tests pass
- New test verifies tuple immutability