### PR TITLE
feat(shell): add max_timeout cap to prevent indefinite process execution

### DIFF
--- a/src/safe_agent/modules/shell.py
+++ b/src/safe_agent/modules/shell.py
@@ -98,6 +98,8 @@ class ShellModule(BaseModule):
         self.working_directory = (
             working_directory.resolve() if working_directory is not None else None
         )
+        if max_timeout <= 0:
+            raise ValueError("max_timeout must be > 0")
         self.default_timeout = default_timeout
         self.max_timeout = max_timeout
         self.max_output_size = max_output_size
@@ -122,7 +124,7 @@ class ShellModule(BaseModule):
                                 "type": "array",
                                 "items": {"type": "string"},
                             },
-                            "timeout": {"type": "number", "minimum": 0},
+                            "timeout": {"type": "number", "exclusiveMinimum": 0},
                             "env": {
                                 "type": "object",
                                 "additionalProperties": {"type": "string"},

--- a/tests/test_modules/test_shell.py
+++ b/tests/test_modules/test_shell.py
@@ -15,6 +15,16 @@ from safe_agent.modules.shell import ShellModule
 class TestShellModuleTimeoutCap:
     """Tests for max_timeout cap behavior (Issue #62)."""
 
+    def test_max_timeout_zero_raises_valueerror(self) -> None:
+        """max_timeout=0 should raise ValueError at construction."""
+        with pytest.raises(ValueError, match="max_timeout must be > 0"):
+            ShellModule(max_timeout=0)
+
+    def test_max_timeout_negative_raises_valueerror(self) -> None:
+        """max_timeout < 0 should raise ValueError at construction."""
+        with pytest.raises(ValueError, match="max_timeout must be > 0"):
+            ShellModule(max_timeout=-1)
+
     async def test_timeout_clamped_to_max_timeout(self, tmp_path: Path) -> None:
         """Per-request timeout exceeding max_timeout should be clamped."""
         module = ShellModule(working_directory=tmp_path, max_timeout=1.0)


### PR DESCRIPTION
## Problem

ShellModule had no upper bound on the timeout parameter. An LLM could request `timeout=999999` (approximately 11.5 days) to keep a subprocess running indefinitely, tying up system resources.

## Solution

- Add `max_timeout` parameter to `ShellModule.__init__()` (default: 300 seconds / 5 minutes)
- Clamp per-request timeouts to `max_timeout` in `_timeout_value()`
- Reject `timeout=0` explicitly (immediate timeout is surprising behavior)

## Changes

- `src/safe_agent/modules/shell.py`:
  - New `max_timeout` init parameter (default 300.0)
  - `_timeout_value()` now clamps to `max_timeout` and rejects 0
- `tests/test_modules/test_shell.py`:
  - 5 new tests for timeout cap behavior

## Testing

```
33 tests passed in test_shell.py
```

Fixes #62