### PR TITLE
feat(email): Add EmailModule with pluggable adapter pattern

### DIFF
--- a/src/safe_agent/modules/email.py
+++ b/src/safe_agent/modules/email.py
@@ -284,7 +284,7 @@ class EmailModule(BaseModule):
     async def _execute_read_inbox(self, params: dict[str, Any]) -> ToolResult[Any]:
         """Execute email:read_inbox by delegating to backend."""
         folder = str(params.get("folder", "inbox"))
-        raw_limit = params.get("limit")
+        raw_limit = params.get("limit", 10)
         if not isinstance(raw_limit, int):
             try:
                 limit = int(raw_limit)  # type: ignore[arg-type]

--- a/tests/test_modules/test_email.py
+++ b/tests/test_modules/test_email.py
@@ -418,6 +418,20 @@ class TestEmailModuleExecute:
 
         assert result.success is True
 
+    async def test_execute_read_inbox_default_limit(self) -> None:
+        """Execute read_inbox should use default limit of 10 if not specified."""
+        backend = MockEmailBackend()
+        module = EmailModule(backend)
+
+        result = await module.execute(
+            "email:read_inbox",
+            {"folder": "inbox"},
+        )
+
+        assert result.success is True
+        # Backend has 2 messages, default limit 10 should return both
+        assert len(result.data["messages"]) == 2
+
     async def test_execute_parse_email_success(self) -> None:
         """Execute parse_email should delegate to backend and return data."""
         backend = MockEmailBackend()


### PR DESCRIPTION
## Overview

Implements #71 - Email interface module using pluggable adapter pattern.

## Design

The framework defines the IAM surface (namespace, tool descriptors, condition keys); a plugin provides the concrete EmailBackend implementation. This allows administrators to write policies against stable identifiers like `email:SendEmail` regardless of whether the backend is SendGrid, Amazon SES, SMTP relay, etc.

## Implementation

### EmailBackend Protocol
- `send(to, subject, body, **kwargs)` - Send email to recipients
- `read_inbox(folder, limit, **kwargs)` - Read messages from mailbox
- `parse(message_id, **kwargs)` - Extract structured data from email body

### EmailModule
- Accepts EmailBackend at construction
- `describe()` returns ModuleDescriptor with 3 tools
- `resolve_conditions()` derives email:Recipient and email:Subject
- `execute()` delegates to backend for all 3 tools

### Tools

| Tool | Action | Resource param | Description |
|------|--------|----------------|-------------|
| `email:send_email` | `email:SendEmail` | `to` | Send an email to recipients |
| `email:read_inbox` | `email:ReadInbox` | `folder` | Read messages from mailbox folder |
| `email:parse_email` | `email:ParseEmail` | `message_id` | Extract structured data from email |

## Tests

27 tests covering:
- `describe()` returns correct descriptor with 3 tools
- `resolve_conditions()` derives condition keys correctly
- `execute()` delegates to backend and returns ToolResult
- `execute()` returns error for unknown tool names
- `execute()` propagates backend errors as failed ToolResult
- Protocol satisfaction verification

## Acceptance Criteria

- [x] EmailBackend protocol defined with send(), read_inbox(), parse() methods
- [x] EmailModule subclasses BaseModule with backend injection via __init__
- [x] describe() returns correct ModuleDescriptor with 3 tools
- [x] resolve_conditions() derives all documented condition keys
- [x] execute() delegates to backend for all 3 tools
- [x] All tests pass with mock backend
- [x] mypy passes with strict typing
- [x] ruff passes with no lint errors