### PR TITLE
ci: add license header validation job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  license:
+    name: License Header Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Check license headers
+        run: python scripts/check_license_headers.py
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest

--- a/scripts/check_license_headers.py
+++ b/scripts/check_license_headers.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Validate that all Python source files have the required Apache 2.0 license header."""
+
+import re
+import sys
+from pathlib import Path
+
+
+# Expected Apache 2.0 license header pattern (flexible on year attribution)
+LICENSE_HEADER_PATTERN = re.compile(
+    r"^# Copyright \d{4}.*\n"
+    r"#\n"
+    r"# Licensed under the Apache License, Version 2\.0 \(the \"License\"\);\n"
+    r"# you may not use this file except in compliance with the License\.\n"
+    r"# You may obtain a copy of the License at\n"
+    r"#\n"
+    r"#\s+http://www\.apache\.org/licenses/LICENSE-2\.0\n"
+    r"#\n"
+    r"# Unless required by applicable law or agreed to in writing, software\n"
+    r"# distributed under the License is distributed on an \"AS IS\" BASIS,\n"
+    r"# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied\.\n"
+    r"# See the License for the specific language governing permissions and\n"
+    r"# limitations under the License\.\n",
+    re.MULTILINE,
+)
+
+
+# Files to exclude from checking
+EXCLUDED_FILES = {"__pycache__", ".pytest_cache", ".mypy_cache", ".ruff_cache"}
+
+
+def find_python_files(directory: Path) -> list[Path]:
+    """Recursively find all Python files in the given directory."""
+    python_files = []
+    for path in directory.rglob("*.py"):
+        # Skip excluded directories
+        if any(part in EXCLUDED_FILES for part in path.parts):
+            continue
+        python_files.append(path)
+    return sorted(python_files)
+
+
+def has_valid_license_header(file_path: Path) -> bool:
+    """Check if a file has a valid Apache 2.0 license header."""
+    try:
+        content = file_path.read_text(encoding="utf-8")
+    except Exception as e:
+        print(f"Error reading {file_path}: {e}")
+        return False
+
+    # Check if the license header pattern matches at the start of the file
+    match = LICENSE_HEADER_PATTERN.match(content)
+    return match is not None
+
+
+def main() -> int:
+    """Main entry point."""
+    # Get the project root (parent of the scripts directory)
+    script_dir = Path(__file__).parent.resolve()
+    project_root = script_dir.parent
+
+    # Check both src and tests directories
+    check_dirs = [project_root / "src", project_root / "tests"]
+
+    missing_headers = []
+    checked_files = []
+
+    for check_dir in check_dirs:
+        if not check_dir.exists():
+            continue
+
+        for py_file in find_python_files(check_dir):
+            checked_files.append(py_file)
+            if not has_valid_license_header(py_file):
+                missing_headers.append(py_file)
+
+    # Print results
+    print(f"Checked {len(checked_files)} Python files.")
+
+    if missing_headers:
+        print(f"\n❌ {len(missing_headers)} file(s) missing valid Apache 2.0 license header:\n")
+        for file_path in missing_headers:
+            rel_path = file_path.relative_to(project_root)
+            print(f"  - {rel_path}")
+        print("\nExpected header format:")
+        print("""
+# Copyright YYYY [Author]
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+""")
+        return 1
+    else:
+        print("✅ All Python files have valid Apache 2.0 license headers.")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for SafeAgentFramework."""

--- a/tests/test_core/__init__.py
+++ b/tests/test_core/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the safe_agent.core package."""

--- a/tests/test_core/test_agent.py
+++ b/tests/test_core/test_agent.py
@@ -1,3 +1,18 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 """Unit tests for Agent."""
 
 from __future__ import annotations

--- a/tests/test_core/test_audit.py
+++ b/tests/test_core/test_audit.py
@@ -1,3 +1,18 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 """Tests for safe_agent.core.audit — AuditLogger and AuditEntry."""
 
 from __future__ import annotations

--- a/tests/test_core/test_dispatcher.py
+++ b/tests/test_core/test_dispatcher.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for safe_agent.core.dispatcher — ToolDispatcher."""
 
 from __future__ import annotations

--- a/tests/test_core/test_event_loop.py
+++ b/tests/test_core/test_event_loop.py
@@ -1,3 +1,18 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 import asyncio
 import json
 from typing import Any

--- a/tests/test_core/test_gateway.py
+++ b/tests/test_core/test_gateway.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Unit tests for Gateway."""
 
 from __future__ import annotations

--- a/tests/test_core/test_llm.py
+++ b/tests/test_core/test_llm.py
@@ -1,3 +1,18 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 """Tests for LLM utility helpers."""
 
 from safe_agent.core.llm import restore_tool_name, sanitize_tool_name

--- a/tests/test_core/test_session.py
+++ b/tests/test_core/test_session.py
@@ -1,3 +1,18 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 """Tests for Session and SessionManager with TTL and eviction."""
 
 import threading

--- a/tests/test_iam/__init__.py
+++ b/tests/test_iam/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the safe_agent.iam package."""

--- a/tests/test_iam/test_evaluator.py
+++ b/tests/test_iam/test_evaluator.py
@@ -1,3 +1,18 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 """Tests for PolicyEvaluator."""
 
 from safe_agent.iam.evaluator import PolicyEvaluator

--- a/tests/test_iam/test_models.py
+++ b/tests/test_iam/test_models.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for IAM Pydantic models."""
 
 import pytest

--- a/tests/test_iam/test_policy.py
+++ b/tests/test_iam/test_policy.py
@@ -1,3 +1,17 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for PolicyStore."""
 
 import json

--- a/tests/test_integration/__init__.py
+++ b/tests/test_integration/__init__.py
@@ -1,0 +1,15 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Integration tests for SafeAgentFramework."""

--- a/tests/test_integration/test_end_to_end.py
+++ b/tests/test_integration/test_end_to_end.py
@@ -1,3 +1,18 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 from __future__ import annotations
 
 import json

--- a/tests/test_modules/__init__.py
+++ b/tests/test_modules/__init__.py
@@ -1,1 +1,15 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Tests for the safe_agent.modules package."""

--- a/tests/test_modules/test_base.py
+++ b/tests/test_modules/test_base.py
@@ -1,3 +1,18 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 """Tests for safe_agent.modules.base — models and BaseModule ABC."""
 
 from typing import Any

--- a/tests/test_modules/test_email.py
+++ b/tests/test_modules/test_email.py
@@ -1,3 +1,18 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 """Tests for the email interface module using pluggable adapter pattern."""
 
 from __future__ import annotations

--- a/tests/test_modules/test_filesystem.py
+++ b/tests/test_modules/test_filesystem.py
@@ -1,3 +1,18 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 """Tests for the sandboxed filesystem module."""
 
 from pathlib import Path

--- a/tests/test_modules/test_registry.py
+++ b/tests/test_modules/test_registry.py
@@ -1,3 +1,18 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 """Tests for safe_agent.modules.registry — ModuleRegistry."""
 
 from typing import Any

--- a/tests/test_modules/test_shell.py
+++ b/tests/test_modules/test_shell.py
@@ -1,3 +1,18 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
 """Tests for the controlled shell execution module."""
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Add CI job that validates all Python source files have the required Apache 2.0 license header.

## Changes

- Added `scripts/check_license_headers.py` - Python script that validates license headers in `src/` and `tests/` directories
- Added new `license` job to `.github/workflows/ci.yml`
- Added missing Apache 2.0 license headers to 21 test files

## How it works

The license check script uses a regex pattern to verify the expected Apache 2.0 header format is present at the beginning of each Python file. The year/author is flexible.

## Testing

- Ran the script locally: all 42 Python files now pass validation
- The CI job will run on all PRs and pushes to main

Fixes #90