### PR TITLE
refactor: rename iam to access

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@
 
 A pluggable, security-first agent framework. Build AI agents that interact with
 system resources (filesystem, shell, etc.) through modules gated by an
-AWS IAM-style policy engine. The agent can attempt any tool call — your policies
+access policy engine. The agent can attempt any tool call — your policies
 decide in code whether to execute it.
 
 ## Current Status
 
 **Active development — MVP complete.** SafeAgentFramework includes:
 
-- **IAM Policy Engine** — JSON policies with Allow/Deny statements, condition operators, and AWS-style evaluation logic
+- **Access Policy Engine** — JSON policies with Allow/Deny statements, condition operators, and policy evaluation
 - **Module Registry** — Pluggable modules with entry point discovery, tool descriptors, and dispatch
 - **Code Gate** — Every LLM tool call passes through policy evaluation before execution
 - **Filesystem Module** — Read/write operations with path-based policy controls
@@ -88,10 +88,10 @@ method works without inheriting from it.
 Three concepts:
 
 1. **Modules** — pluggable Python classes that provide tools (filesystem, shell,
-   etc.). Each module describes its tools and what IAM action/resource they
+   etc.). Each module describes its tools and what access action/resource they
    map to.
 2. **Policies** — JSON documents that allow or deny actions on resources.
-   Deny-by-default. Explicit deny always wins. Same evaluation logic as AWS IAM.
+   Deny-by-default. Explicit deny always wins. Same evaluation logic as industry-standard policy engines.
 3. **Code gate** — every tool call from the LLM passes through policy evaluation
    in application code. No prompt-based guardrails. The LLM never sees the
    policies.

--- a/src/safe_agent/access/__init__.py
+++ b/src/safe_agent/access/__init__.py
@@ -12,21 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""IAM Policy Engine for SafeAgent.
+"""Access Policy Engine for SafeAgent.
 
-Provides AWS IAM-style policy evaluation with Allow/Deny statements,
+Provides access policy evaluation with Allow/Deny statements,
 wildcard action/resource matching, and condition operators.
 """
 
-from safe_agent.iam.evaluator import PolicyEvaluator
-from safe_agent.iam.models import (
+from safe_agent.access.evaluator import PolicyEvaluator
+from safe_agent.access.models import (
     AuthorizationRequest,
     AuthorizationResult,
     Decision,
     Policy,
     Statement,
 )
-from safe_agent.iam.policy import PolicyStore
+from safe_agent.access.policy import PolicyStore
 
 __all__ = [
     "AuthorizationRequest",

--- a/src/safe_agent/access/evaluator.py
+++ b/src/safe_agent/access/evaluator.py
@@ -20,13 +20,13 @@ import fnmatch
 import math
 from typing import Any
 
-from safe_agent.iam.models import (
+from safe_agent.access.models import (
     AuthorizationRequest,
     AuthorizationResult,
     Decision,
     Statement,
 )
-from safe_agent.iam.policy import PolicyStore
+from safe_agent.access.policy import PolicyStore
 
 
 def _safe_float(value: Any) -> float | None:
@@ -157,9 +157,9 @@ def _evaluate_condition_block(
 
     Args:
         condition: The ``Condition`` dict from a
-            :class:`~safe_agent.iam.models.Statement`.
+            :class:`~safe_agent.access.models.Statement`.
         context: The ``context`` dict from the
-            :class:`~safe_agent.iam.models.AuthorizationRequest`.
+            :class:`~safe_agent.access.models.AuthorizationRequest`.
 
     Returns:
         ``True`` if all condition clauses are satisfied, ``False`` otherwise.
@@ -207,9 +207,9 @@ def _evaluate_condition_block(
 
 
 class PolicyEvaluator:
-    """Evaluates :class:`~safe_agent.iam.models.AuthorizationRequest` objects.
+    """Evaluates :class:`~safe_agent.access.models.AuthorizationRequest` objects.
 
-    Implements a 5-step AWS IAM-style evaluation algorithm:
+    Implements a 5-step policy evaluation algorithm:
 
     1. Default deny.
     2. Collect statements whose ``Action`` and ``Resource`` patterns match the
@@ -237,11 +237,11 @@ class PolicyEvaluator:
         """Evaluate *request* against all loaded policies.
 
         Args:
-            request: The :class:`~safe_agent.iam.models.AuthorizationRequest`
+            request: The :class:`~safe_agent.access.models.AuthorizationRequest`
                 to evaluate.
 
         Returns:
-            An :class:`~safe_agent.iam.models.AuthorizationResult` describing
+            An :class:`~safe_agent.access.models.AuthorizationResult` describing
             the decision, reason, and matched statements.
         """
         # Step 1: Default deny

--- a/src/safe_agent/access/models.py
+++ b/src/safe_agent/access/models.py
@@ -12,11 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Pydantic models for the IAM Policy Engine.
+"""Pydantic models for the Access Policy Engine.
 
 Defines the core data structures used for policy representation and
-authorization request/response handling, using AWS IAM-style JSON keys
-via Pydantic field aliases.
+authorization request/response handling, using JSON field aliases.
 """
 
 from __future__ import annotations
@@ -62,7 +61,7 @@ class Statement(BaseModel):
 
 
 class Policy(BaseModel):
-    """A top-level IAM-style policy document.
+    """A top-level access policy document.
 
     Attributes:
         version: The policy format version. Must be ``"2025-01"``.

--- a/src/safe_agent/access/policy.py
+++ b/src/safe_agent/access/policy.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""PolicyStore for loading and managing IAM policy documents."""
+"""PolicyStore for loading and managing access policy documents."""
 
 from __future__ import annotations
 
@@ -23,13 +23,13 @@ from typing import cast
 
 from pydantic import ValidationError
 
-from safe_agent.iam.models import Policy, Statement
+from safe_agent.access.models import Policy, Statement
 
 VALID_VERSIONS = {"2025-01"}
 
 
 class PolicyStore:
-    """Stores and manages a collection of IAM policies.
+    """Stores and manages a collection of access policies.
 
     Policies can be loaded from JSON files or added programmatically.
     Once frozen, no further policies may be added.
@@ -50,7 +50,7 @@ class PolicyStore:
     def load(self, directory: Path) -> None:
         """Load all ``.json`` policy files from *directory*.
 
-        Each file is parsed as a :class:`~safe_agent.iam.models.Policy`.
+        Each file is parsed as a :class:`~safe_agent.access.models.Policy`.
         Files whose ``Version`` field is not ``"2025-01"`` are rejected
         with a :class:`ValueError`.
 
@@ -96,7 +96,7 @@ class PolicyStore:
         """Add a single policy to the store.
 
         Args:
-            policy: A validated :class:`~safe_agent.iam.models.Policy` instance.
+            policy: A validated :class:`~safe_agent.access.models.Policy` instance.
 
         Raises:
             ValueError: If the policy's ``version`` is not ``"2025-01"``.
@@ -137,7 +137,7 @@ class PolicyStore:
         modify the cached statements.
 
         Returns:
-            A flat sequence of :class:`~safe_agent.iam.models.Statement` objects
+            A flat sequence of :class:`~safe_agent.access.models.Statement` objects
             in the order they were added.
         """
         if self._frozen:

--- a/src/safe_agent/core/agent.py
+++ b/src/safe_agent/core/agent.py
@@ -18,14 +18,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from safe_agent.access.evaluator import PolicyEvaluator
+from safe_agent.access.policy import PolicyStore
 from safe_agent.core.audit import AuditLogger
 from safe_agent.core.dispatcher import ToolDispatcher
 from safe_agent.core.event_loop import EventLoop
 from safe_agent.core.gateway import Gateway
 from safe_agent.core.llm import LLMClient
 from safe_agent.core.session import SessionManager
-from safe_agent.iam.evaluator import PolicyEvaluator
-from safe_agent.iam.policy import PolicyStore
 from safe_agent.modules.base import BaseModule
 from safe_agent.modules.registry import ModuleRegistry
 

--- a/src/safe_agent/core/audit.py
+++ b/src/safe_agent/core/audit.py
@@ -26,7 +26,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from safe_agent.iam.models import Decision
+from safe_agent.access.models import Decision
 
 _logger = logging.getLogger(__name__)
 

--- a/src/safe_agent/core/dispatcher.py
+++ b/src/safe_agent/core/dispatcher.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from safe_agent.access.evaluator import PolicyEvaluator
+from safe_agent.access.models import AuthorizationRequest, Decision
 from safe_agent.core.audit import AuditEntry, AuditLogger
-from safe_agent.iam.evaluator import PolicyEvaluator
-from safe_agent.iam.models import AuthorizationRequest, Decision
 from safe_agent.modules.base import ToolResult
 from safe_agent.modules.registry import ModuleRegistry
 
@@ -49,8 +49,9 @@ class ToolDispatcher:
        a single empty-string resource (``""``). The policy must explicitly allow
        ``resource=""`` for such tools — there is no implicit pass.
     3. Call ``module.resolve_conditions()`` to obtain runtime context values.
-    4. For each resource: build an :class:`~safe_agent.iam.models.AuthorizationRequest`
-       and call :meth:`~safe_agent.iam.evaluator.PolicyEvaluator.evaluate`.
+    4. For each resource: build an :class:`~safe_agent.access.models.
+       AuthorizationRequest` and call :meth:`~safe_agent.access.evaluator.
+       PolicyEvaluator.evaluate`.
     5. Log every decision via :class:`~safe_agent.core.audit.AuditLogger`.
        Every outcome — allowed, denied, unknown-tool, internal error — produces
        an audit entry. There is no silent dispatch path.
@@ -72,7 +73,7 @@ class ToolDispatcher:
     Args:
         registry: The :class:`~safe_agent.modules.registry.ModuleRegistry`
             containing all registered modules.
-        evaluator: The :class:`~safe_agent.iam.evaluator.PolicyEvaluator`
+        evaluator: The :class:`~safe_agent.access.evaluator.PolicyEvaluator`
             for authorisation decisions.
         audit_logger: The :class:`~safe_agent.core.audit.AuditLogger` for
             recording every decision.

--- a/src/safe_agent/modules/email.py
+++ b/src/safe_agent/modules/email.py
@@ -102,7 +102,7 @@ class EmailBackend(Protocol):
 class EmailModule(BaseModule):
     """Email interface module using pluggable adapter pattern.
 
-    The framework defines the IAM surface (namespace, tool descriptors,
+    The framework defines the access control surface (namespace, tool descriptors,
     condition keys); a plugin provides the concrete EmailBackend implementation.
     This allows administrators to write policies against stable identifiers
     like "email:SendEmail" regardless of whether the backend is SendGrid,

--- a/tests/test_access/__init__.py
+++ b/tests/test_access/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for the safe_agent.iam package."""
+"""Tests for the safe_agent.access package."""

--- a/tests/test_access/test_evaluator.py
+++ b/tests/test_access/test_evaluator.py
@@ -15,13 +15,13 @@
 
 """Tests for PolicyEvaluator."""
 
-from safe_agent.iam.evaluator import PolicyEvaluator
-from safe_agent.iam.models import (
+from safe_agent.access.evaluator import PolicyEvaluator
+from safe_agent.access.models import (
     AuthorizationRequest,
     Decision,
     Policy,
 )
-from safe_agent.iam.policy import PolicyStore
+from safe_agent.access.policy import PolicyStore
 
 
 def make_store(*policy_dicts) -> PolicyStore:

--- a/tests/test_access/test_models.py
+++ b/tests/test_access/test_models.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for IAM Pydantic models."""
+"""Tests for access policy Pydantic models."""
 
 import pytest
 from pydantic import ValidationError
 
-from safe_agent.iam.models import (
+from safe_agent.access.models import (
     AuthorizationRequest,
     AuthorizationResult,
     Decision,

--- a/tests/test_access/test_policy.py
+++ b/tests/test_access/test_policy.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Tests for PolicyStore."""
+"""Tests for PolicyStore — access policy document loading and management."""
 
 import json
 from pathlib import Path
 
 import pytest
 
-from safe_agent.iam.models import Policy
-from safe_agent.iam.policy import PolicyStore
+from safe_agent.access.models import Policy
+from safe_agent.access.policy import PolicyStore
 
 VALID_POLICY = {
     "Version": "2025-01",

--- a/tests/test_core/test_audit.py
+++ b/tests/test_core/test_audit.py
@@ -21,8 +21,8 @@ import json
 import threading
 from pathlib import Path
 
+from safe_agent.access.models import Decision
 from safe_agent.core.audit import AuditEntry, AuditLogger
-from safe_agent.iam.models import Decision
 
 
 def _make_entry(**overrides) -> AuditEntry:

--- a/tests/test_core/test_dispatcher.py
+++ b/tests/test_core/test_dispatcher.py
@@ -22,11 +22,11 @@ from unittest.mock import patch
 
 import pytest
 
+from safe_agent.access.evaluator import PolicyEvaluator
+from safe_agent.access.models import Decision, Policy
+from safe_agent.access.policy import PolicyStore
 from safe_agent.core.audit import AuditLogger
 from safe_agent.core.dispatcher import ToolDispatcher
-from safe_agent.iam.evaluator import PolicyEvaluator
-from safe_agent.iam.models import Decision, Policy
-from safe_agent.iam.policy import PolicyStore
 from safe_agent.modules.base import (
     BaseModule,
     ModuleDescriptor,

--- a/tests/test_integration/test_end_to_end.py
+++ b/tests/test_integration/test_end_to_end.py
@@ -22,8 +22,8 @@ from typing import Any
 import pytest
 
 from safe_agent import Agent
+from safe_agent.access.models import Decision, Policy, Statement
 from safe_agent.core.llm import LLMClient, LLMResponse, ToolCall
-from safe_agent.iam.models import Decision, Policy, Statement
 from safe_agent.modules.base import (
     BaseModule,
     ModuleDescriptor,


### PR DESCRIPTION
Rename iam module to access and remove AWS references from docstrings.

- safe_agent.iam -> safe_agent.access
- tests/test_iam -> tests/test_access
- Updated all imports
- Removed AWS/IAM terminology from docs

Fixes #91