### PR TITLE
feat: add Messaging module with pluggable adapter pattern

### DIFF
--- a/src/safe_agent/modules/__init__.py
+++ b/src/safe_agent/modules/__init__.py
@@ -20,10 +20,13 @@ from safe_agent.modules.base import (
     ToolDescriptor,
     ToolResult,
 )
+from safe_agent.modules.messaging import MessagingBackend, MessagingModule
 from safe_agent.modules.registry import ModuleRegistry
 
 __all__ = [
     "BaseModule",
+    "MessagingBackend",
+    "MessagingModule",
     "ModuleDescriptor",
     "ModuleRegistry",
     "ToolDescriptor",

--- a/src/safe_agent/modules/messaging.py
+++ b/src/safe_agent/modules/messaging.py
@@ -87,7 +87,7 @@ class MessagingModule(BaseModule):
     delegating actual message operations to an injected backend provider.
 
     Attributes:
-        backend: The messaging backend implementation.
+        _backend: The messaging backend implementation (private).
     """
 
     def __init__(self, backend: MessagingBackend) -> None:
@@ -97,7 +97,7 @@ class MessagingModule(BaseModule):
             backend: An implementation of MessagingBackend that handles
                 actual message operations for a specific platform.
         """
-        self.backend = backend
+        self._backend = backend
 
     def describe(self) -> ModuleDescriptor:
         """Return the messaging module descriptor and tool definitions."""
@@ -111,9 +111,18 @@ class MessagingModule(BaseModule):
                     parameters={
                         "type": "object",
                         "properties": {
-                            "channel": {"type": "string"},
-                            "text": {"type": "string"},
-                            "thread_id": {"type": "string"},
+                            "channel": {
+                                "type": "string",
+                                "description": "Target channel or user identifier.",
+                            },
+                            "text": {
+                                "type": "string",
+                                "description": "Message content to send.",
+                            },
+                            "thread_id": {
+                                "type": "string",
+                                "description": "Optional thread to reply within.",
+                            },
                         },
                         "required": ["channel", "text"],
                         "additionalProperties": False,
@@ -131,9 +140,22 @@ class MessagingModule(BaseModule):
                     parameters={
                         "type": "object",
                         "properties": {
-                            "channel": {"type": "string"},
-                            "limit": {"type": "integer"},
-                            "since": {"type": "string"},
+                            "channel": {
+                                "type": "string",
+                                "description": "Source channel identifier.",
+                            },
+                            "limit": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": "Maximum number of messages to return.",
+                            },
+                            "since": {
+                                "type": "string",
+                                "format": "date-time",
+                                "description": (
+                                    "Optional ISO 8601 timestamp to filter messages."
+                                ),
+                            },
                         },
                         "required": ["channel", "limit"],
                         "additionalProperties": False,
@@ -142,7 +164,6 @@ class MessagingModule(BaseModule):
                     resource_param=["channel"],
                     condition_keys=[
                         "messaging:Channel",
-                        "messaging:Recipient",
                     ],
                 ),
             ],
@@ -157,7 +178,7 @@ class MessagingModule(BaseModule):
 
         Derives condition keys for policy evaluation:
             - messaging:Channel: The target channel identifier.
-            - messaging:Recipient: Inferred recipient for DM channels.
+            - messaging:Recipient: Inferred recipient for DM channels (send only).
 
         Args:
             tool_name: The name of the tool being invoked.
@@ -175,10 +196,21 @@ class MessagingModule(BaseModule):
             "messaging:Channel": channel_str,
         }
 
-        # Infer recipient for DM-style channels (e.g., "@username", "D12345")
-        # This is a heuristic; backends may override with more precise logic.
-        if channel_str.startswith("@") or channel_str.upper().startswith("D"):
-            conditions["messaging:Recipient"] = channel_str.lstrip("@")
+        # Only infer recipient for send_message tool (not read_messages)
+        # and only for clear DM patterns:
+        #   - "@username" style (explicit user mention)
+        #   - "D" followed by digits (Slack DM channel convention: D12345)
+        # Avoid false positives on "#dev", "#design", "deployment-alerts", etc.
+        normalized_tool = tool_name.removeprefix("messaging:")
+        if normalized_tool == "send_message":
+            if channel_str.startswith("@"):
+                conditions["messaging:Recipient"] = channel_str.lstrip("@")
+            elif (
+                len(channel_str) > 1
+                and channel_str[0] == "D"
+                and channel_str[1:].isdigit()
+            ):
+                conditions["messaging:Recipient"] = channel_str
 
         return conditions
 
@@ -214,7 +246,7 @@ class MessagingModule(BaseModule):
         if "thread_id" in params:
             kwargs["thread_id"] = params["thread_id"]
 
-        result = await self.backend.send_message(channel, text, **kwargs)
+        result = await self._backend.send_message(channel, text, **kwargs)
         return ToolResult(success=True, data=result)
 
     async def _read_messages(self, params: dict[str, Any]) -> ToolResult[Any]:
@@ -225,5 +257,5 @@ class MessagingModule(BaseModule):
         if "since" in params:
             kwargs["since"] = params["since"]
 
-        messages = await self.backend.read_messages(channel, limit, **kwargs)
+        messages = await self._backend.read_messages(channel, limit, **kwargs)
         return ToolResult(success=True, data={"messages": messages})

--- a/tests/test_modules/test_messaging.py
+++ b/tests/test_modules/test_messaging.py
@@ -26,6 +26,8 @@ class MockMessagingBackend:
         """Initialize mock backend with storage for sent messages."""
         self.sent_messages: list[dict[str, Any]] = []
         self.stored_messages: dict[str, list[dict[str, Any]]] = {}
+        # Track kwargs passed to read_messages
+        self.last_read_kwargs: dict[str, Any] = {}
 
     async def send_message(
         self,
@@ -50,6 +52,7 @@ class MockMessagingBackend:
         **kwargs: Any,
     ) -> list[dict[str, Any]]:
         """Mock read_messages that returns stored messages for the channel."""
+        self.last_read_kwargs = kwargs  # Track what kwargs were passed
         messages = self.stored_messages.get(channel, [])
         return messages[:limit]
 
@@ -94,7 +97,8 @@ class TestMessagingModule:
 
         assert read_tool.action == "messaging:ReadMessages"
         assert read_tool.resource_param == ["channel"]
-        assert read_tool.condition_keys == ["messaging:Channel", "messaging:Recipient"]
+        # read_messages should NOT have messaging:Recipient (semantically wrong)
+        assert read_tool.condition_keys == ["messaging:Channel"]
 
     async def test_send_message_delegates_to_backend(self) -> None:
         """send_message should delegate to the backend and return success."""
@@ -178,6 +182,8 @@ class TestMessagingModule:
 
         assert result.success is True
         assert result.data == {"messages": [{"id": "m1", "text": "Message 1"}]}
+        # Verify the since kwarg was actually forwarded to the backend
+        assert backend.last_read_kwargs.get("since") == "2026-03-26T00:00:00Z"
 
     async def test_execute_returns_error_for_unknown_tool(self) -> None:
         """Execute should return error for unknown tool names."""
@@ -242,7 +248,24 @@ class TestMessagingModule:
             "messaging:Recipient": "alice",
         }
 
-        # Test D-style DM (Slack convention)
+        # Test D-style DM (Slack convention: D followed by digits)
+        conditions = await module.resolve_conditions(
+            "messaging:send_message",
+            {"channel": "D12345", "text": "hello"},
+        )
+
+        assert conditions == {
+            "messaging:Channel": "D12345",
+            "messaging:Recipient": "D12345",
+        }
+
+    async def test_resolve_conditions_no_recipient_for_read_messages(
+        self,
+    ) -> None:
+        """read_messages should not get messaging:Recipient condition key."""
+        backend = MockMessagingBackend()
+        module = MessagingModule(backend)
+
         conditions = await module.resolve_conditions(
             "messaging:read_messages",
             {"channel": "D12345", "limit": 10},
@@ -250,7 +273,41 @@ class TestMessagingModule:
 
         assert conditions == {
             "messaging:Channel": "D12345",
-            "messaging:Recipient": "D12345",
+        }
+
+    async def test_resolve_conditions_no_false_positive_recipient(self) -> None:
+        """resolve_conditions should not infer Recipient for #dev, #design, etc."""
+        backend = MockMessagingBackend()
+        module = MessagingModule(backend)
+
+        # Test that #dev does NOT get Recipient (D prefix on its own)
+        conditions = await module.resolve_conditions(
+            "messaging:send_message",
+            {"channel": "#dev", "text": "hello"},
+        )
+
+        assert conditions == {
+            "messaging:Channel": "#dev",
+        }
+
+        # Test that #design does NOT get Recipient
+        conditions = await module.resolve_conditions(
+            "messaging:send_message",
+            {"channel": "#design", "text": "hello"},
+        )
+
+        assert conditions == {
+            "messaging:Channel": "#design",
+        }
+
+        # Test that deployment-alerts does NOT get Recipient
+        conditions = await module.resolve_conditions(
+            "messaging:send_message",
+            {"channel": "deployment-alerts", "text": "hello"},
+        )
+
+        assert conditions == {
+            "messaging:Channel": "deployment-alerts",
         }
 
     async def test_resolve_conditions_returns_empty_for_missing_channel(


### PR DESCRIPTION
## Summary

Implements the Messaging module per issue #72 with a pluggable adapter pattern.

### Backend Protocol
- `MessagingBackend` Protocol with `send_message()` and `read_messages()` async methods
- Runtime-checkable for validation

### Module Class
- `MessagingModule(BaseModule)` accepts a `MessagingBackend` at construction
- `describe()` returns module descriptor with 2 tools
- `resolve_conditions()` derives `messaging:Channel` and `messaging:Recipient` condition keys
- `execute()` delegates to the injected backend

### Tool Descriptors
| Tool | Action | Resource param |
|------|--------|----------------|
| `messaging:send_message` | `messaging:SendMessage` | channel |
| `messaging:read_messages` | `messaging:ReadMessages` | channel |

### Parameters
- `send_message`: channel (string, required), text (string, required), thread_id (string, optional)
- `read_messages`: channel (string, required), limit (integer, required), since (string, optional — ISO 8601 timestamp)

### Tests
- 12 tests using mock backend covering all acceptance criteria

## Checklist
- [x] MessagingBackend protocol defined
- [x] MessagingModule subclasses BaseModule with backend injection
- [x] describe() returns correct ModuleDescriptor with 2 tools
- [x] resolve_conditions() derives documented condition keys
- [x] execute() delegates to backend for both tools
- [x] All tests pass with mock backend
- [x] mypy passes with strict typing
- [x] ruff passes with no lint errors

Closes #72