### PR TITLE
feat: implement Web Search module (pluggable adapter) (#74)

### DIFF
--- a/src/safe_agent/modules/web_search.py
+++ b/src/safe_agent/modules/web_search.py
@@ -1,0 +1,191 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pluggable web search module for SafeAgent.
+
+This module provides a web search interface that delegates to an injected backend
+provider. The framework defines the interface; a plugin provides the concrete
+implementation (Brave Search, Google Custom Search, Bing, etc.).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from safe_agent.modules.base import (
+    BaseModule,
+    ModuleDescriptor,
+    ToolDescriptor,
+    ToolResult,
+)
+
+
+@runtime_checkable
+class WebSearchBackend(Protocol):
+    """Protocol for web search backend implementations.
+
+    Implementations provide concrete integrations with search providers
+    such as Brave Search, Google Custom Search, Bing, etc.
+
+    Methods:
+        search: Execute a web search and return results.
+    """
+
+    async def search(
+        self,
+        query: str,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        """Execute a web search and return results.
+
+        Args:
+            query: The search query string.
+            **kwargs: Backend-specific options (e.g., max_results, domain_filter).
+
+        Returns:
+            List of result dicts with title, url, snippet, etc.
+        """
+        ...
+
+
+class WebSearchModule(BaseModule):
+    """Web search module using the pluggable adapter pattern.
+
+    This module exposes web search tools to the SafeAgent framework while
+    delegating actual search operations to an injected backend provider.
+
+    Attributes:
+        _backend: The web search backend implementation (private).
+    """
+
+    def __init__(self, backend: WebSearchBackend) -> None:
+        """Initialize the web search module with a backend provider.
+
+        Args:
+            backend: An implementation of WebSearchBackend that handles
+                actual search operations for a specific provider.
+        """
+        self._backend = backend
+
+    def describe(self) -> ModuleDescriptor:
+        """Return the web search module descriptor and tool definitions."""
+        return ModuleDescriptor(
+            namespace="web_search",
+            description=(
+                "Search the web for documentation, CVEs, vendor "
+                "advisories, and known issues."
+            ),
+            tools=[
+                ToolDescriptor(
+                    name="web_search:search",
+                    description="Execute a web search and return results.",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "query": {
+                                "type": "string",
+                                "description": "The search query string.",
+                            },
+                            "max_results": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": "Maximum number of results to return.",
+                            },
+                            "domain_filter": {
+                                "type": "string",
+                                "description": (
+                                    "Optional domain to restrict results "
+                                    "(e.g., 'docs.python.org')."
+                                ),
+                            },
+                        },
+                        "required": ["query"],
+                        "additionalProperties": False,
+                    },
+                    action="web_search:Search",
+                    resource_param=["query"],
+                    condition_keys=[
+                        "web_search:QueryDomain",
+                    ],
+                ),
+            ],
+        )
+
+    async def resolve_conditions(
+        self,
+        tool_name: str,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Resolve web search condition values from the domain_filter parameter.
+
+        Derives condition keys for policy evaluation:
+            - web_search:QueryDomain: The domain filter if specified.
+
+        Args:
+            tool_name: The name of the tool being invoked.
+            params: The input parameters for the invocation.
+
+        Returns:
+            Dict mapping condition keys to resolved values.
+        """
+        domain_filter = params.get("domain_filter")
+        if domain_filter is None:
+            return {}
+
+        domain_str = str(domain_filter)
+        conditions: dict[str, Any] = {
+            "web_search:QueryDomain": domain_str,
+        }
+
+        return conditions
+
+    async def execute(
+        self,
+        tool_name: str,
+        params: dict[str, Any],
+    ) -> ToolResult[Any]:
+        """Execute a web search tool invocation by delegating to the backend.
+
+        Args:
+            tool_name: The name of the tool to execute.
+            params: The input parameters for the tool.
+
+        Returns:
+            A ToolResult indicating success or failure, plus any data.
+        """
+        try:
+            normalized_tool = tool_name.removeprefix("web_search:")
+            if normalized_tool == "search":
+                return await self._search(params)
+            return ToolResult(success=False, error=f"Unknown tool: {tool_name}")
+        except Exception as exc:
+            return ToolResult(success=False, error=str(exc))
+
+    async def _search(self, params: dict[str, Any]) -> ToolResult[Any]:
+        """Delegate search to the backend."""
+        if "query" not in params:
+            return ToolResult(
+                success=False,
+                error="Missing required parameter: query",
+            )
+
+        query = str(params["query"])
+        kwargs: dict[str, Any] = {}
+        if "max_results" in params:
+            kwargs["max_results"] = int(params["max_results"])
+        if "domain_filter" in params:
+            kwargs["domain_filter"] = params["domain_filter"]
+
+        results = await self._backend.search(query, **kwargs)
+        return ToolResult(success=True, data={"results": results})

--- a/tests/test_modules/test_web_search.py
+++ b/tests/test_modules/test_web_search.py
@@ -1,0 +1,221 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the pluggable web search module."""
+
+from typing import Any
+
+from safe_agent.modules.web_search import WebSearchBackend, WebSearchModule
+
+
+class MockWebSearchBackend:
+    """Mock backend for testing WebSearchModule."""
+
+    def __init__(self) -> None:
+        """Initialize mock backend with storage for search results."""
+        self.search_results: list[dict[str, Any]] = []
+        # Track kwargs passed to search
+        self.last_search_kwargs: dict[str, Any] = {}
+
+    async def search(
+        self,
+        query: str,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        """Mock search that returns stored results."""
+        self.last_search_kwargs = kwargs  # Track what kwargs were passed
+        return self.search_results
+
+
+class TestWebSearchModule:
+    """Tests for WebSearchModule operations and descriptors."""
+
+    def test_describe_returns_valid_descriptor(self) -> None:
+        """describe() should return the expected module metadata."""
+        backend = MockWebSearchBackend()
+        module = WebSearchModule(backend)
+
+        descriptor = module.describe()
+
+        assert descriptor.namespace == "web_search"
+        assert len(descriptor.tools) == 1
+        tool_names = {tool.name for tool in descriptor.tools}
+        assert tool_names == {"web_search:search"}
+
+    def test_describe_tools_have_correct_actions_and_resource_params(
+        self,
+    ) -> None:
+        """Tools should have correct action names and resource params."""
+        backend = MockWebSearchBackend()
+        module = WebSearchModule(backend)
+
+        descriptor = module.describe()
+
+        search_tool = next(
+            tool for tool in descriptor.tools if tool.name == "web_search:search"
+        )
+
+        assert search_tool.action == "web_search:Search"
+        assert search_tool.resource_param == ["query"]
+        assert search_tool.condition_keys == ["web_search:QueryDomain"]
+
+    async def test_search_delegates_to_backend(self) -> None:
+        """Search should delegate to the backend and return success."""
+        backend = MockWebSearchBackend()
+        backend.search_results = [
+            {
+                "title": "Result 1",
+                "url": "https://example.com/1",
+                "snippet": "First",
+            },
+            {
+                "title": "Result 2",
+                "url": "https://example.com/2",
+                "snippet": "Second",
+            },
+        ]
+        module = WebSearchModule(backend)
+
+        result = await module.execute(
+            "web_search:search",
+            {"query": "test query"},
+        )
+
+        assert result.success is True
+        assert result.data == {
+            "results": [
+                {
+                    "title": "Result 1",
+                    "url": "https://example.com/1",
+                    "snippet": "First",
+                },
+                {
+                    "title": "Result 2",
+                    "url": "https://example.com/2",
+                    "snippet": "Second",
+                },
+            ]
+        }
+
+    async def test_search_with_max_results_and_domain_filter(self) -> None:
+        """Search should pass through optional max_results and domain_filter."""
+        backend = MockWebSearchBackend()
+        backend.search_results = [
+            {
+                "title": "Python Docs",
+                "url": "https://docs.python.org/3",
+                "snippet": "Python",
+            },
+        ]
+        module = WebSearchModule(backend)
+
+        result = await module.execute(
+            "web_search:search",
+            {
+                "query": "python async",
+                "max_results": 5,
+                "domain_filter": "docs.python.org",
+            },
+        )
+
+        assert result.success is True
+        assert result.data == {
+            "results": [
+                {
+                    "title": "Python Docs",
+                    "url": "https://docs.python.org/3",
+                    "snippet": "Python",
+                },
+            ]
+        }
+        # Verify the kwargs were actually forwarded to the backend
+        assert backend.last_search_kwargs.get("max_results") == 5
+        assert backend.last_search_kwargs.get("domain_filter") == "docs.python.org"
+
+    async def test_execute_returns_error_for_unknown_tool(self) -> None:
+        """Execute should return error for unknown tool names."""
+        backend = MockWebSearchBackend()
+        module = WebSearchModule(backend)
+
+        result = await module.execute(
+            "web_search:unknown_tool",
+            {"query": "test"},
+        )
+
+        assert result.success is False
+        assert result.error == "Unknown tool: web_search:unknown_tool"
+
+    async def test_backend_error_propagates_as_tool_result_error(self) -> None:
+        """Backend errors should be caught and returned as ToolResult errors."""
+
+        class FailingBackend(MockWebSearchBackend):
+            async def search(self, query: str, **kwargs: Any) -> list[dict[str, Any]]:
+                raise RuntimeError("API rate limit exceeded")
+
+        backend = FailingBackend()
+        module = WebSearchModule(backend)
+
+        result = await module.execute(
+            "web_search:search",
+            {"query": "test"},
+        )
+
+        assert result.success is False
+        assert result.error == "API rate limit exceeded"
+
+    async def test_search_missing_query_returns_error(self) -> None:
+        """Search without required query param should return clear error."""
+        backend = MockWebSearchBackend()
+        module = WebSearchModule(backend)
+
+        result = await module.execute(
+            "web_search:search",
+            {},  # Missing query
+        )
+
+        assert result.success is False
+        assert result.error == "Missing required parameter: query"
+
+    async def test_resolve_conditions_derives_query_domain(self) -> None:
+        """Resolve web_search:QueryDomain from domain_filter."""
+        backend = MockWebSearchBackend()
+        module = WebSearchModule(backend)
+
+        conditions = await module.resolve_conditions(
+            "web_search:search",
+            {"query": "python async", "domain_filter": "docs.python.org"},
+        )
+
+        assert conditions == {
+            "web_search:QueryDomain": "docs.python.org",
+        }
+
+    async def test_resolve_conditions_returns_empty_if_no_domain_filter(
+        self,
+    ) -> None:
+        """Return empty dict when domain_filter not present."""
+        backend = MockWebSearchBackend()
+        module = WebSearchModule(backend)
+
+        conditions = await module.resolve_conditions(
+            "web_search:search",
+            {"query": "python async"},
+        )
+
+        assert conditions == {}
+
+    def test_backend_protocol_check(self) -> None:
+        """MockWebSearchBackend should satisfy the WebSearchBackend protocol."""
+        backend = MockWebSearchBackend()
+        assert isinstance(backend, WebSearchBackend)


### PR DESCRIPTION
This PR implements the Web Search module as specified in #74.

## Changes

- **WebSearchBackend Protocol** with `search(query: str, **kwargs) -> list[dict]` method
- **WebSearchModule** implementing the pluggable adapter pattern:
  - Tool: `web_search:search` with parameters:
    - `query` (string, required)
    - `max_results` (integer, optional)
    - `domain_filter` (string, optional)
  - IAM action: `web_search:Search`
  - Condition key: `web_search:QueryDomain` derived from `domain_filter`
- **Comprehensive tests** with mock backend
- **Follows patterns** from messaging.py (pluggable adapter reference implementation)

## Checklist

- [x] All tests pass (9 new tests)
- [x] ruff check passes
- [x] ruff format applied
- [x] Follows architecture.md spec (lines 547-560)

Closes #74