### PR TITLE
feat: implement Alerting module (S8)

### DIFF
--- a/src/safe_agent/modules/__init__.py
+++ b/src/safe_agent/modules/__init__.py
@@ -14,6 +14,7 @@
 
 """SafeAgent modules package — public re-exports."""
 
+from safe_agent.modules.alerting import AlertingBackend, AlertingModule
 from safe_agent.modules.base import (
     BaseModule,
     ModuleDescriptor,
@@ -26,6 +27,8 @@ from safe_agent.modules.registry import ModuleRegistry
 from safe_agent.modules.vault import VaultBackend, VaultModule
 
 __all__ = [
+    "AlertingBackend",
+    "AlertingModule",
     "BaseModule",
     "DatabaseBackend",
     "DatabaseModule",

--- a/src/safe_agent/modules/alerting.py
+++ b/src/safe_agent/modules/alerting.py
@@ -1,0 +1,560 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Alerting module for SafeAgent.
+
+This module provides alert management capabilities through a pluggable
+backend protocol. The framework defines the interface; a plugin provides the
+concrete implementation (PagerDuty, OpsGenie, Grafana, etc.).
+
+Security Considerations:
+    - Alert Visibility: Alert data returned in ToolResult.data may be visible
+      to the LLM. Avoid querying sensitive alert content without proper access
+      controls.
+
+    - Privileged Actions: acknowledge_alert, escalate_alert, and silence_alert
+      modify alert state and should be treated as privileged actions. Policy
+      conditions should restrict access appropriately.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Protocol, runtime_checkable
+
+from safe_agent.modules.base import (
+    BaseModule,
+    ModuleDescriptor,
+    ToolDescriptor,
+    ToolResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class AlertingBackend(Protocol):
+    """Protocol for alerting backend implementations.
+
+    Implementations provide concrete integrations with alerting systems
+    such as PagerDuty, OpsGenie, Grafana, VictorOps, etc.
+
+    Methods:
+        list_alerts: Retrieve alerts with optional filtering.
+        acknowledge_alert: Mark an alert as acknowledged.
+        escalate_alert: Escalate an alert to a higher priority or team.
+        silence_alert: Silence an alert for a specified duration.
+    """
+
+    async def list_alerts(
+        self,
+        *,
+        severity: str | None = None,
+        source: str | None = None,
+        state: str | None = None,
+        limit: int | None = None,
+    ) -> dict[str, Any]:
+        """Retrieve alerts with optional filtering.
+
+        Args:
+            severity: Optional severity filter (e.g., "critical", "warning").
+            source: Optional alert source filter (e.g., "prometheus", "cloudwatch").
+            state: Optional alert state filter (e.g., "firing", "acknowledged").
+            limit: Optional limit on number of alerts to return.
+
+        Returns:
+            Dict containing alert results with at minimum:
+                - "alerts": List of alert dicts.
+                - "total_count": Total number of alerts matching the query.
+
+        Raises:
+            Exception: If the query fails.
+        """
+        ...
+
+    async def acknowledge_alert(
+        self,
+        alert_id: str,
+        *,
+        note: str | None = None,
+    ) -> dict[str, Any]:
+        """Mark an alert as acknowledged.
+
+        Args:
+            alert_id: The unique identifier of the alert.
+            note: Optional note to attach to the acknowledgement.
+
+        Returns:
+            Dict containing result with at minimum:
+                - "acknowledged": Boolean indicating success.
+                - "alert_id": The alert identifier.
+
+        Raises:
+            Exception: If the acknowledgement fails.
+        """
+        ...
+
+    async def escalate_alert(
+        self,
+        alert_id: str,
+        *,
+        target: str | None = None,
+        note: str | None = None,
+    ) -> dict[str, Any]:
+        """Escalate an alert to a higher priority or team.
+
+        Args:
+            alert_id: The unique identifier of the alert.
+            target: Optional team or individual to escalate to.
+            note: Optional note for the escalation.
+
+        Returns:
+            Dict containing result with at minimum:
+                - "escalated": Boolean indicating success.
+                - "alert_id": The alert identifier.
+
+        Raises:
+            Exception: If the escalation fails.
+        """
+        ...
+
+    async def silence_alert(
+        self,
+        alert_id: str,
+        *,
+        duration_minutes: int | None = None,
+        reason: str | None = None,
+    ) -> dict[str, Any]:
+        """Silence an alert for a specified duration.
+
+        Args:
+            alert_id: The unique identifier of the alert.
+            duration_minutes: Duration to silence the alert in minutes.
+            reason: Optional reason for silencing.
+
+        Returns:
+            Dict containing result with at minimum:
+                - "silenced": Boolean indicating success.
+                - "alert_id": The alert identifier.
+                - "silenced_until": ISO timestamp when silence expires.
+
+        Raises:
+            Exception: If silencing fails.
+        """
+        ...
+
+
+class AlertingModule(BaseModule):
+    """Alerting module using the pluggable adapter pattern.
+
+    This module exposes alert management tools to the SafeAgent framework while
+    delegating actual alerting operations to an injected backend provider.
+
+    Attributes:
+        _backend: The alerting backend implementation (private).
+    """
+
+    def __init__(self, backend: AlertingBackend) -> None:
+        """Initialize the alerting module with a backend provider.
+
+        Args:
+            backend: An implementation of AlertingBackend that handles
+                actual alerting operations for a specific platform.
+        """
+        self._backend = backend
+
+    def describe(self) -> ModuleDescriptor:
+        """Return the alerting module descriptor and tool definitions."""
+        return ModuleDescriptor(
+            namespace="alerting",
+            description="Manage alerts through an alerting system backend.",
+            tools=[
+                ToolDescriptor(
+                    name="alerting:list_alerts",
+                    description=(
+                        "List alerts with optional filtering by severity and source."
+                    ),
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "source": {
+                                "type": "string",
+                                "description": (
+                                    "Filter by alert source "
+                                    "(e.g., 'prometheus', 'cloudwatch')."
+                                ),
+                            },
+                            "severity": {
+                                "type": "string",
+                                "description": (
+                                    "Filter by severity (e.g., 'critical', 'warning')."
+                                ),
+                            },
+                            "state": {
+                                "type": "string",
+                                "description": (
+                                    "Filter by alert state "
+                                    "(e.g., 'firing', 'acknowledged')."
+                                ),
+                            },
+                            "limit": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": ("Maximum number of alerts to return."),
+                            },
+                        },
+                        "required": [],
+                        "additionalProperties": False,
+                    },
+                    action="alerting:ListAlerts",
+                    resource_param=["source"],
+                    condition_keys=[
+                        "alerting:Severity",
+                        "alerting:AlertSource",
+                    ],
+                ),
+                ToolDescriptor(
+                    name="alerting:acknowledge_alert",
+                    description="Acknowledge an alert by its ID.",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "alert_id": {
+                                "type": "string",
+                                "description": ("The unique identifier of the alert."),
+                            },
+                            "note": {
+                                "type": "string",
+                                "description": (
+                                    "Optional note to attach to the acknowledgement."
+                                ),
+                            },
+                        },
+                        "required": ["alert_id"],
+                        "additionalProperties": False,
+                    },
+                    action="alerting:AcknowledgeAlert",
+                    resource_param=["alert_id"],
+                    condition_keys=[
+                        "alerting:Severity",
+                        "alerting:AlertSource",
+                    ],
+                ),
+                ToolDescriptor(
+                    name="alerting:escalate_alert",
+                    description="Escalate an alert to a higher priority or team.",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "alert_id": {
+                                "type": "string",
+                                "description": "The unique identifier of the alert.",
+                            },
+                            "target": {
+                                "type": "string",
+                                "description": (
+                                    "Optional team or individual to escalate to."
+                                ),
+                            },
+                            "note": {
+                                "type": "string",
+                                "description": "Optional note for the escalation.",
+                            },
+                        },
+                        "required": ["alert_id"],
+                        "additionalProperties": False,
+                    },
+                    action="alerting:EscalateAlert",
+                    resource_param=["alert_id"],
+                    condition_keys=[
+                        "alerting:Severity",
+                        "alerting:AlertSource",
+                    ],
+                ),
+                ToolDescriptor(
+                    name="alerting:silence_alert",
+                    description="Silence an alert for a specified duration.",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "alert_id": {
+                                "type": "string",
+                                "description": ("The unique identifier of the alert."),
+                            },
+                            "duration": {
+                                "type": "string",
+                                "description": (
+                                    "Duration to silence the alert (e.g., '1h', '30m')."
+                                ),
+                            },
+                            "reason": {
+                                "type": "string",
+                                "description": ("Optional reason for silencing."),
+                            },
+                        },
+                        "required": ["alert_id", "duration"],
+                        "additionalProperties": False,
+                    },
+                    action="alerting:SilenceAlert",
+                    resource_param=["alert_id"],
+                    condition_keys=[
+                        "alerting:Severity",
+                        "alerting:AlertSource",
+                    ],
+                ),
+            ],
+        )
+
+    async def resolve_conditions(
+        self,
+        tool_name: str,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Resolve alerting condition values from parameters.
+
+        Derives condition keys for policy evaluation:
+            - alerting:Severity: The severity filter (for list_alerts) or
+              alert severity (for other tools, if available).
+            - alerting:AlertSource: The source filter (for list_alerts) or
+              alert source (for other tools, if available).
+
+        Args:
+            tool_name: The name of the tool being invoked.
+            params: The input parameters for the invocation.
+
+        Returns:
+            Dict mapping condition keys to resolved values.
+        """
+        conditions: dict[str, Any] = {}
+
+        # For list_alerts, derive from filter parameters
+        severity = params.get("severity")
+        if severity is not None:
+            conditions["alerting:Severity"] = str(severity)
+
+        source = params.get("source")
+        if source is not None:
+            conditions["alerting:AlertSource"] = str(source)
+
+        return conditions
+
+    async def execute(
+        self,
+        tool_name: str,
+        params: dict[str, Any],
+    ) -> ToolResult[Any]:
+        """Execute an alerting tool invocation by delegating to the backend.
+
+        Args:
+            tool_name: The name of the tool to execute.
+            params: The input parameters for the tool.
+
+        Returns:
+            A ToolResult indicating success or failure, plus any data.
+        """
+        try:
+            normalized_tool = tool_name.removeprefix("alerting:")
+            if normalized_tool == "list_alerts":
+                return await self._list_alerts(params)
+            if normalized_tool == "acknowledge_alert":
+                return await self._acknowledge_alert(params)
+            if normalized_tool == "escalate_alert":
+                return await self._escalate_alert(params)
+            if normalized_tool == "silence_alert":
+                return await self._silence_alert(params)
+            return ToolResult(success=False, error=f"Unknown tool: {tool_name}")
+        except Exception as exc:
+            return ToolResult(success=False, error=str(exc))
+
+    async def _list_alerts(self, params: dict[str, Any]) -> ToolResult[Any]:
+        """Delegate list_alerts to the backend.
+
+        Security Note:
+            Logs the query parameters at DEBUG level. Alert content is NOT logged.
+        """
+        kwargs: dict[str, Any] = {}
+        if "severity" in params:
+            kwargs["severity"] = str(params["severity"])
+        if "source" in params:
+            kwargs["source"] = str(params["source"])
+        if "state" in params:
+            kwargs["state"] = str(params["state"])
+        if "limit" in params:
+            kwargs["limit"] = int(params["limit"])
+
+        logger.debug("Alerting list_alerts: %s", kwargs)
+
+        result = await self._backend.list_alerts(**kwargs)
+        return ToolResult(success=True, data=result)
+
+    async def _acknowledge_alert(self, params: dict[str, Any]) -> ToolResult[Any]:
+        """Delegate acknowledge_alert to the backend.
+
+        Security Note:
+            Logs the alert_id at INFO level for audit trail.
+            Note content is logged at DEBUG level to avoid logging PII.
+        """
+        alert_id = params.get("alert_id")
+        if alert_id is None:
+            return ToolResult(
+                success=False,
+                error="Missing required parameter: alert_id",
+            )
+        alert_id = str(alert_id)
+        if not alert_id or not alert_id.strip():
+            return ToolResult(
+                success=False,
+                error="alert_id must not be empty",
+            )
+
+        kwargs: dict[str, Any] = {}
+        if "note" in params:
+            kwargs["note"] = str(params["note"])
+
+        logger.info("Alerting acknowledge_alert: alert_id=%s", alert_id)
+        logger.debug("Alerting acknowledge_alert kwargs: %s", kwargs)
+
+        result = await self._backend.acknowledge_alert(alert_id, **kwargs)
+        return ToolResult(success=True, data=result)
+
+    async def _escalate_alert(self, params: dict[str, Any]) -> ToolResult[Any]:
+        """Delegate escalate_alert to the backend.
+
+        Security Note:
+            Logs the alert_id at INFO level for audit trail.
+            Escalation details are logged at DEBUG level.
+        """
+        alert_id = params.get("alert_id")
+        if alert_id is None:
+            return ToolResult(
+                success=False,
+                error="Missing required parameter: alert_id",
+            )
+        alert_id = str(alert_id)
+        if not alert_id or not alert_id.strip():
+            return ToolResult(
+                success=False,
+                error="alert_id must not be empty",
+            )
+
+        kwargs: dict[str, Any] = {}
+        if "target" in params:
+            kwargs["target"] = str(params["target"])
+        if "note" in params:
+            kwargs["note"] = str(params["note"])
+
+        logger.info("Alerting escalate_alert: alert_id=%s", alert_id)
+        logger.debug("Alerting escalate_alert kwargs: %s", kwargs)
+
+        result = await self._backend.escalate_alert(alert_id, **kwargs)
+        return ToolResult(success=True, data=result)
+
+    async def _silence_alert(self, params: dict[str, Any]) -> ToolResult[Any]:
+        """Delegate silence_alert to the backend.
+
+        Security Note:
+            Logs the alert_id and duration at INFO level for audit trail.
+            Reason is logged at DEBUG level to avoid logging PII.
+        """
+        alert_id = params.get("alert_id")
+        if alert_id is None:
+            return ToolResult(
+                success=False,
+                error="Missing required parameter: alert_id",
+            )
+        alert_id = str(alert_id)
+        if not alert_id or not alert_id.strip():
+            return ToolResult(
+                success=False,
+                error="alert_id must not be empty",
+            )
+
+        duration = params.get("duration")
+        if duration is None:
+            return ToolResult(
+                success=False,
+                error="Missing required parameter: duration",
+            )
+        duration_str = str(duration)
+        duration_minutes = self._parse_duration(duration_str)
+        if duration_minutes is None:
+            return ToolResult(
+                success=False,
+                error=(
+                    "Invalid duration format. Use formats like '1h', '30m', '1h30m'."
+                ),
+            )
+        if duration_minutes < 1:
+            return ToolResult(
+                success=False,
+                error="duration must be at least 1 minute",
+            )
+
+        kwargs: dict[str, Any] = {"duration_minutes": duration_minutes}
+        if "reason" in params:
+            kwargs["reason"] = str(params["reason"])
+
+        logger.info(
+            "Alerting silence_alert: alert_id=%s duration=%s (%d minutes)",
+            alert_id,
+            duration_str,
+            duration_minutes,
+        )
+        logger.debug("Alerting silence_alert kwargs: %s", kwargs)
+
+        result = await self._backend.silence_alert(alert_id, **kwargs)
+        return ToolResult(success=True, data=result)
+
+    def _parse_duration(self, duration: str) -> int | None:
+        """Parse a duration string into minutes.
+
+        Supports formats like:
+        - "30m" - 30 minutes
+        - "1h" - 1 hour (60 minutes)
+        - "1h30m" - 1 hour 30 minutes (90 minutes)
+        - "2h15m" - 2 hours 15 minutes (135 minutes)
+
+        Args:
+            duration: The duration string to parse.
+
+        Returns:
+            The duration in minutes, or None if parsing fails.
+        """
+        import re
+
+        duration = duration.strip().lower()
+        if not duration:
+            return None
+
+        total_minutes = 0
+        pattern = re.compile(r"^(\d+h)?(\d+m)?$")
+
+        # Handle combined format like "1h30m"
+        match = pattern.match(duration)
+        if match:
+            hours_part = match.group(1)
+            minutes_part = match.group(2)
+
+            if hours_part:
+                total_minutes += int(hours_part[:-1]) * 60
+            if minutes_part:
+                total_minutes += int(minutes_part[:-1])
+
+            return total_minutes if total_minutes > 0 else None
+
+        # Handle simple integer string (treat as minutes)
+        if duration.isdigit():
+            return int(duration)
+
+        return None

--- a/tests/test_modules/test_alerting.py
+++ b/tests/test_modules/test_alerting.py
@@ -1,0 +1,797 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the alerting module."""
+
+from unittest.mock import AsyncMock
+
+from safe_agent.modules.alerting import AlertingModule
+
+
+class MockAlertingBackend:
+    """Mock implementation of AlertingBackend for testing."""
+
+    def __init__(self) -> None:
+        """Initialize the mock backend with async mocks."""
+        self.list_alerts = AsyncMock(return_value={"alerts": [], "total_count": 0})
+        self.acknowledge_alert = AsyncMock(
+            return_value={"acknowledged": True, "alert_id": "test-123"}
+        )
+        self.escalate_alert = AsyncMock(
+            return_value={"escalated": True, "alert_id": "test-123"}
+        )
+        self.silence_alert = AsyncMock(
+            return_value={
+                "silenced": True,
+                "alert_id": "test-123",
+                "silenced_until": "2024-01-01T00:00:00Z",
+            }
+        )
+
+
+class TestAlertingModule:
+    """Tests for AlertingModule operations and descriptors."""
+
+    def test_describe_returns_valid_descriptor(self) -> None:
+        """describe() should return the expected module metadata."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        descriptor = module.describe()
+
+        assert descriptor.namespace == "alerting"
+        assert len(descriptor.tools) == 4
+        tool_names = {tool.name for tool in descriptor.tools}
+        assert tool_names == {
+            "alerting:list_alerts",
+            "alerting:acknowledge_alert",
+            "alerting:escalate_alert",
+            "alerting:silence_alert",
+        }
+
+    def test_describe_has_correct_tool_names(self) -> None:
+        """Tool names should follow namespace:snake_case format."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        descriptor = module.describe()
+
+        for tool in descriptor.tools:
+            assert tool.name.startswith("alerting:")
+            # Check snake_case format (no PascalCase)
+            suffix = tool.name.removeprefix("alerting:")
+            assert suffix.islower() or "_" in suffix
+
+    def test_describe_has_correct_actions(self) -> None:
+        """Actions should follow alerting:PascalCase format."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        descriptor = module.describe()
+
+        actions = {tool.action for tool in descriptor.tools}
+        assert actions == {
+            "alerting:ListAlerts",
+            "alerting:AcknowledgeAlert",
+            "alerting:EscalateAlert",
+            "alerting:SilenceAlert",
+        }
+
+    def test_describe_has_correct_resource_params(self) -> None:
+        """list_alerts uses source as resource_param, other tools use alert_id."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        descriptor = module.describe()
+
+        for tool in descriptor.tools:
+            if tool.name == "alerting:list_alerts":
+                # list_alerts uses source as resource
+                assert tool.resource_param == ["source"]
+            else:
+                # Other tools use alert_id as resource
+                assert tool.resource_param == ["alert_id"]
+
+    def test_describe_has_correct_condition_keys(self) -> None:
+        """Tools should declare alerting:Severity and alerting:AlertSource."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        descriptor = module.describe()
+
+        for tool in descriptor.tools:
+            assert "alerting:Severity" in tool.condition_keys
+            assert "alerting:AlertSource" in tool.condition_keys
+
+    def test_describe_parameters_have_additional_properties_false(self) -> None:
+        """Parameter schemas should have additionalProperties: False."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        descriptor = module.describe()
+
+        for tool in descriptor.tools:
+            assert tool.parameters.get("additionalProperties") is False
+
+
+class TestAlertingModuleResolveConditions:
+    """Tests for resolve_conditions method."""
+
+    async def test_resolve_conditions_derives_severity(self) -> None:
+        """resolve_conditions should derive alerting:Severity from params."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        conditions = await module.resolve_conditions(
+            "alerting:list_alerts",
+            {"severity": "critical"},
+        )
+
+        assert conditions.get("alerting:Severity") == "critical"
+
+    async def test_resolve_conditions_derives_source(self) -> None:
+        """resolve_conditions should derive alerting:AlertSource from params."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        conditions = await module.resolve_conditions(
+            "alerting:list_alerts",
+            {"source": "prometheus"},
+        )
+
+        assert conditions.get("alerting:AlertSource") == "prometheus"
+
+    async def test_resolve_conditions_derives_both_severity_and_source(self) -> None:
+        """resolve_conditions should derive both condition keys when present."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        conditions = await module.resolve_conditions(
+            "alerting:list_alerts",
+            {"severity": "warning", "source": "cloudwatch"},
+        )
+
+        assert conditions.get("alerting:Severity") == "warning"
+        assert conditions.get("alerting:AlertSource") == "cloudwatch"
+
+    async def test_resolve_conditions_returns_empty_without_params(self) -> None:
+        """resolve_conditions should handle missing filter parameters."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        conditions = await module.resolve_conditions(
+            "alerting:list_alerts",
+            {},
+        )
+
+        assert conditions == {}
+
+    async def test_resolve_conditions_coerces_non_string_severity(self) -> None:
+        """resolve_conditions should coerce non-string severity to string."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        conditions = await module.resolve_conditions(
+            "alerting:list_alerts",
+            {"severity": 123},
+        )
+
+        assert conditions.get("alerting:Severity") == "123"
+
+
+class TestAlertingModuleExecute:
+    """Tests for execute method delegation to backend."""
+
+    async def test_execute_delegates_list_alerts_to_backend(self) -> None:
+        """execute() should delegate list_alerts to the backend."""
+        backend = MockAlertingBackend()
+        backend.list_alerts.return_value = {
+            "alerts": [{"id": "alert-1", "severity": "critical"}],
+            "total_count": 1,
+        }
+        module = AlertingModule(backend)
+
+        result = await module.execute("alerting:list_alerts", {})
+
+        assert result.success is True
+        assert result.data == {
+            "alerts": [{"id": "alert-1", "severity": "critical"}],
+            "total_count": 1,
+        }
+        backend.list_alerts.assert_called_once_with()
+
+    async def test_execute_delegates_list_alerts_with_filters(self) -> None:
+        """execute() should pass filter parameters to backend."""
+        backend = MockAlertingBackend()
+        backend.list_alerts.return_value = {"alerts": [], "total_count": 0}
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:list_alerts",
+            {
+                "severity": "critical",
+                "source": "prometheus",
+                "state": "firing",
+                "limit": 10,
+            },
+        )
+
+        assert result.success is True
+        backend.list_alerts.assert_called_once_with(
+            severity="critical",
+            source="prometheus",
+            state="firing",
+            limit=10,
+        )
+
+    async def test_execute_delegates_list_alerts_with_state_filter(self) -> None:
+        """execute() should pass state parameter to backend."""
+        backend = MockAlertingBackend()
+        backend.list_alerts.return_value = {"alerts": [], "total_count": 0}
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:list_alerts",
+            {"state": "acknowledged"},
+        )
+
+        assert result.success is True
+        backend.list_alerts.assert_called_once_with(state="acknowledged")
+
+    async def test_execute_delegates_acknowledge_alert_to_backend(self) -> None:
+        """execute() should delegate acknowledge_alert to the backend."""
+        backend = MockAlertingBackend()
+        backend.acknowledge_alert.return_value = {
+            "acknowledged": True,
+            "alert_id": "alert-123",
+        }
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:acknowledge_alert",
+            {"alert_id": "alert-123"},
+        )
+
+        assert result.success is True
+        assert result.data == {"acknowledged": True, "alert_id": "alert-123"}
+        backend.acknowledge_alert.assert_called_once_with("alert-123")
+
+    async def test_execute_delegates_acknowledge_alert_with_note(self) -> None:
+        """execute() should pass note parameter to backend."""
+        backend = MockAlertingBackend()
+        backend.acknowledge_alert.return_value = {
+            "acknowledged": True,
+            "alert_id": "alert-123",
+        }
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:acknowledge_alert",
+            {"alert_id": "alert-123", "note": "Investigating"},
+        )
+
+        assert result.success is True
+        backend.acknowledge_alert.assert_called_once_with(
+            "alert-123",
+            note="Investigating",
+        )
+
+    async def test_execute_delegates_escalate_alert_to_backend(self) -> None:
+        """execute() should delegate escalate_alert to the backend."""
+        backend = MockAlertingBackend()
+        backend.escalate_alert.return_value = {
+            "escalated": True,
+            "alert_id": "alert-456",
+        }
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:escalate_alert",
+            {"alert_id": "alert-456"},
+        )
+
+        assert result.success is True
+        assert result.data == {"escalated": True, "alert_id": "alert-456"}
+        backend.escalate_alert.assert_called_once_with("alert-456")
+
+    async def test_execute_delegates_escalate_alert_with_options(self) -> None:
+        """execute() should pass escalation options to backend."""
+        backend = MockAlertingBackend()
+        backend.escalate_alert.return_value = {
+            "escalated": True,
+            "alert_id": "alert-456",
+        }
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:escalate_alert",
+            {
+                "alert_id": "alert-456",
+                "target": "oncall-primary",
+                "note": "Customer impact detected",
+            },
+        )
+
+        assert result.success is True
+        backend.escalate_alert.assert_called_once_with(
+            "alert-456",
+            target="oncall-primary",
+            note="Customer impact detected",
+        )
+
+    async def test_execute_delegates_silence_alert_to_backend(self) -> None:
+        """execute() should delegate silence_alert to the backend."""
+        backend = MockAlertingBackend()
+        backend.silence_alert.return_value = {
+            "silenced": True,
+            "alert_id": "alert-789",
+            "silenced_until": "2024-01-01T01:00:00Z",
+        }
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:silence_alert",
+            {"alert_id": "alert-789", "duration": "1h"},
+        )
+
+        assert result.success is True
+        assert result.data == {
+            "silenced": True,
+            "alert_id": "alert-789",
+            "silenced_until": "2024-01-01T01:00:00Z",
+        }
+        backend.silence_alert.assert_called_once_with(
+            "alert-789",
+            duration_minutes=60,
+        )
+
+    async def test_execute_delegates_silence_alert_with_reason(self) -> None:
+        """execute() should pass reason parameter to backend."""
+        backend = MockAlertingBackend()
+        backend.silence_alert.return_value = {
+            "silenced": True,
+            "alert_id": "alert-789",
+            "silenced_until": "2024-01-01T01:00:00Z",
+        }
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:silence_alert",
+            {
+                "alert_id": "alert-789",
+                "duration": "1h",
+                "reason": "Planned maintenance",
+            },
+        )
+
+        assert result.success is True
+        backend.silence_alert.assert_called_once_with(
+            "alert-789",
+            duration_minutes=60,
+            reason="Planned maintenance",
+        )
+
+    async def test_execute_returns_error_for_unknown_tool(self) -> None:
+        """execute() should return error for unknown tool names."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        result = await module.execute("alerting:unknown_tool", {})
+
+        assert result.success is False
+        assert "Unknown tool" in result.error
+
+    async def test_backend_error_propagates_as_tool_result_failure(self) -> None:
+        """Backend exceptions should become ToolResult(success=False)."""
+        backend = MockAlertingBackend()
+        backend.list_alerts.side_effect = Exception("Connection refused")
+        module = AlertingModule(backend)
+
+        result = await module.execute("alerting:list_alerts", {})
+
+        assert result.success is False
+        assert result.error == "Connection refused"
+
+    async def test_acknowledge_alert_backend_error_propagates(self) -> None:
+        """acknowledge_alert backend errors should propagate as failures."""
+        backend = MockAlertingBackend()
+        backend.acknowledge_alert.side_effect = Exception("Alert not found")
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:acknowledge_alert",
+            {"alert_id": "nonexistent"},
+        )
+
+        assert result.success is False
+        assert result.error == "Alert not found"
+
+    async def test_escalate_alert_backend_error_propagates(self) -> None:
+        """escalate_alert backend errors should propagate as failures."""
+        backend = MockAlertingBackend()
+        backend.escalate_alert.side_effect = Exception("Permission denied")
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:escalate_alert",
+            {"alert_id": "alert-123"},
+        )
+
+        assert result.success is False
+        assert result.error == "Permission denied"
+
+    async def test_silence_alert_backend_error_propagates(self) -> None:
+        """silence_alert backend errors should propagate as failures."""
+        backend = MockAlertingBackend()
+        backend.silence_alert.side_effect = Exception("Invalid duration")
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:silence_alert",
+            {"alert_id": "alert-123", "duration": "1h"},
+        )
+
+        assert result.success is False
+        assert result.error == "Invalid duration"
+
+
+class TestAlertingModuleValidation:
+    """Tests for parameter validation."""
+
+    async def test_acknowledge_alert_validates_missing_alert_id(self) -> None:
+        """acknowledge_alert should return error for missing alert_id."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        result = await module.execute("alerting:acknowledge_alert", {})
+
+        assert result.success is False
+        assert "Missing required parameter: alert_id" in result.error
+        backend.acknowledge_alert.assert_not_called()
+
+    async def test_acknowledge_alert_validates_empty_alert_id(self) -> None:
+        """acknowledge_alert should return error for empty alert_id."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:acknowledge_alert",
+            {"alert_id": ""},
+        )
+
+        assert result.success is False
+        assert "alert_id must not be empty" in result.error
+        backend.acknowledge_alert.assert_not_called()
+
+    async def test_acknowledge_alert_validates_whitespace_alert_id(self) -> None:
+        """acknowledge_alert should return error for whitespace-only alert_id."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:acknowledge_alert",
+            {"alert_id": "   "},
+        )
+
+        assert result.success is False
+        assert "alert_id must not be empty" in result.error
+        backend.acknowledge_alert.assert_not_called()
+
+    async def test_escalate_alert_validates_missing_alert_id(self) -> None:
+        """escalate_alert should return error for missing alert_id."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        result = await module.execute("alerting:escalate_alert", {})
+
+        assert result.success is False
+        assert "Missing required parameter: alert_id" in result.error
+        backend.escalate_alert.assert_not_called()
+
+    async def test_escalate_alert_validates_empty_alert_id(self) -> None:
+        """escalate_alert should return error for empty alert_id."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:escalate_alert",
+            {"alert_id": ""},
+        )
+
+        assert result.success is False
+        assert "alert_id must not be empty" in result.error
+        backend.escalate_alert.assert_not_called()
+
+    async def test_silence_alert_validates_missing_alert_id(self) -> None:
+        """silence_alert should return error for missing alert_id."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:silence_alert",
+            {"duration": "1h"},
+        )
+
+        assert result.success is False
+        assert "Missing required parameter: alert_id" in result.error
+        backend.silence_alert.assert_not_called()
+
+    async def test_silence_alert_validates_missing_duration(self) -> None:
+        """silence_alert should return error for missing duration."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:silence_alert",
+            {"alert_id": "alert-123"},
+        )
+
+        assert result.success is False
+        assert "Missing required parameter: duration" in result.error
+        backend.silence_alert.assert_not_called()
+
+    async def test_silence_alert_validates_invalid_duration_format(self) -> None:
+        """silence_alert should return error for invalid duration format."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:silence_alert",
+            {"alert_id": "alert-123", "duration": "invalid"},
+        )
+
+        assert result.success is False
+        assert "Invalid duration format" in result.error
+        backend.silence_alert.assert_not_called()
+
+    async def test_silence_alert_validates_empty_duration(self) -> None:
+        """silence_alert should return error for empty duration."""
+        backend = MockAlertingBackend()
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:silence_alert",
+            {"alert_id": "alert-123", "duration": ""},
+        )
+
+        assert result.success is False
+        assert "Invalid duration format" in result.error
+        backend.silence_alert.assert_not_called()
+
+    async def test_silence_alert_accepts_minimum_duration(self) -> None:
+        """silence_alert should accept duration of '1m'."""
+        backend = MockAlertingBackend()
+        backend.silence_alert.return_value = {
+            "silenced": True,
+            "alert_id": "alert-123",
+            "silenced_until": "2024-01-01T00:01:00Z",
+        }
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:silence_alert",
+            {"alert_id": "alert-123", "duration": "1m"},
+        )
+
+        assert result.success is True
+        backend.silence_alert.assert_called_once_with(
+            "alert-123",
+            duration_minutes=1,
+        )
+
+
+class TestAlertingModuleEdgeCases:
+    """Tests for edge cases and parameter handling."""
+
+    async def test_list_alerts_coerces_non_string_severity(self) -> None:
+        """list_alerts should coerce non-string severity to string."""
+        backend = MockAlertingBackend()
+        backend.list_alerts.return_value = {"alerts": [], "total_count": 0}
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:list_alerts",
+            {"severity": 123},
+        )
+
+        assert result.success is True
+        backend.list_alerts.assert_called_once_with(severity="123")
+
+    async def test_acknowledge_alert_coerces_non_string_alert_id(self) -> None:
+        """acknowledge_alert should coerce non-string alert_id to string."""
+        backend = MockAlertingBackend()
+        backend.acknowledge_alert.return_value = {
+            "acknowledged": True,
+            "alert_id": "12345",
+        }
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:acknowledge_alert",
+            {"alert_id": 12345},
+        )
+
+        assert result.success is True
+        backend.acknowledge_alert.assert_called_once_with("12345")
+
+    async def test_silence_alert_parses_hour_duration(self) -> None:
+        """silence_alert should parse '1h' duration format."""
+        backend = MockAlertingBackend()
+        backend.silence_alert.return_value = {
+            "silenced": True,
+            "alert_id": "alert-123",
+            "silenced_until": "2024-01-01T01:00:00Z",
+        }
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:silence_alert",
+            {"alert_id": "alert-123", "duration": "1h"},
+        )
+
+        assert result.success is True
+        backend.silence_alert.assert_called_once_with(
+            "alert-123",
+            duration_minutes=60,
+        )
+
+    async def test_silence_alert_parses_minute_duration(self) -> None:
+        """silence_alert should parse '30m' duration format."""
+        backend = MockAlertingBackend()
+        backend.silence_alert.return_value = {
+            "silenced": True,
+            "alert_id": "alert-123",
+            "silenced_until": "2024-01-01T00:30:00Z",
+        }
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:silence_alert",
+            {"alert_id": "alert-123", "duration": "30m"},
+        )
+
+        assert result.success is True
+        backend.silence_alert.assert_called_once_with(
+            "alert-123",
+            duration_minutes=30,
+        )
+
+    async def test_silence_alert_parses_combined_duration(self) -> None:
+        """silence_alert should parse '1h30m' combined duration format."""
+        backend = MockAlertingBackend()
+        backend.silence_alert.return_value = {
+            "silenced": True,
+            "alert_id": "alert-123",
+            "silenced_until": "2024-01-01T01:30:00Z",
+        }
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:silence_alert",
+            {"alert_id": "alert-123", "duration": "1h30m"},
+        )
+
+        assert result.success is True
+        backend.silence_alert.assert_called_once_with(
+            "alert-123",
+            duration_minutes=90,
+        )
+
+    async def test_silence_alert_parses_hours_only(self) -> None:
+        """silence_alert should parse '2h' duration format."""
+        backend = MockAlertingBackend()
+        backend.silence_alert.return_value = {
+            "silenced": True,
+            "alert_id": "alert-123",
+            "silenced_until": "2024-01-01T02:00:00Z",
+        }
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:silence_alert",
+            {"alert_id": "alert-123", "duration": "2h"},
+        )
+
+        assert result.success is True
+        backend.silence_alert.assert_called_once_with(
+            "alert-123",
+            duration_minutes=120,
+        )
+
+    async def test_silence_alert_parses_plain_number_as_minutes(self) -> None:
+        """silence_alert should parse plain number string as minutes."""
+        backend = MockAlertingBackend()
+        backend.silence_alert.return_value = {
+            "silenced": True,
+            "alert_id": "alert-123",
+            "silenced_until": "2024-01-01T00:45:00Z",
+        }
+        module = AlertingModule(backend)
+
+        result = await module.execute(
+            "alerting:silence_alert",
+            {"alert_id": "alert-123", "duration": "45"},
+        )
+
+        assert result.success is True
+        backend.silence_alert.assert_called_once_with(
+            "alert-123",
+            duration_minutes=45,
+        )
+
+    async def test_list_alerts_handles_empty_params_dict(self) -> None:
+        """list_alerts should handle empty params dict."""
+        backend = MockAlertingBackend()
+        backend.list_alerts.return_value = {"alerts": [], "total_count": 0}
+        module = AlertingModule(backend)
+
+        result = await module.execute("alerting:list_alerts", {})
+
+        assert result.success is True
+        backend.list_alerts.assert_called_once_with()
+
+    async def test_list_alerts_handles_partial_filters(self) -> None:
+        """list_alerts should handle partial filter parameters."""
+        backend = MockAlertingBackend()
+        backend.list_alerts.return_value = {"alerts": [], "total_count": 0}
+        module = AlertingModule(backend)
+
+        # Only severity, no source or limit
+        result = await module.execute(
+            "alerting:list_alerts",
+            {"severity": "warning"},
+        )
+
+        assert result.success is True
+        backend.list_alerts.assert_called_once_with(severity="warning")
+
+    async def test_escalate_alert_handles_empty_optional_params(self) -> None:
+        """escalate_alert should handle empty optional parameters."""
+        backend = MockAlertingBackend()
+        backend.escalate_alert.return_value = {
+            "escalated": True,
+            "alert_id": "alert-123",
+        }
+        module = AlertingModule(backend)
+
+        # No escalation_policy or message
+        result = await module.execute(
+            "alerting:escalate_alert",
+            {"alert_id": "alert-123"},
+        )
+
+        assert result.success is True
+        backend.escalate_alert.assert_called_once_with("alert-123")
+
+    async def test_silence_alert_handles_empty_reason(self) -> None:
+        """silence_alert should handle missing reason parameter."""
+        backend = MockAlertingBackend()
+        backend.silence_alert.return_value = {
+            "silenced": True,
+            "alert_id": "alert-123",
+            "silenced_until": "2024-01-01T01:00:00Z",
+        }
+        module = AlertingModule(backend)
+
+        # No reason provided
+        result = await module.execute(
+            "alerting:silence_alert",
+            {"alert_id": "alert-123", "duration": "1h"},
+        )
+
+        assert result.success is True
+        backend.silence_alert.assert_called_once_with(
+            "alert-123",
+            duration_minutes=60,
+        )


### PR DESCRIPTION
## Summary

Implements the Alerting module as specified in #78 - a pluggable adapter pattern for integrating alerting platforms (PagerDuty, OpsGenie, Alertmanager, etc.).

## Changes

- **AlertingBackend Protocol**: Interface with async methods for list_alerts(), acknowledge_alert(), escalate_alert(), silence_alert()
- **AlertingModule**: Full module implementation with 4 tools:
  - alerting:list_alerts → Alerting:ListAlerts
  - alerting:acknowledge_alert → Alerting:AcknowledgeAlert
  - alerting:escalate_alert → Alerting:EscalateAlert
  - alerting:silence_alert → Alerting:SilenceAlert
- **Condition resolution**: alerting:Severity, alerting:AlertSource
- **Tests**: 42 new comprehensive tests (mock backend-based)

## Verification

- ✅ 546 tests passing (42 new + 504 existing)
- ✅ mypy --strict clean
- ✅ ruff check/format clean
- ✅ JSON Schema with additionalProperties: False

Closes #78