### PR TITLE
feat: error_tracking module with pluggable adapter (closes #79)

### DIFF
--- a/src/safe_agent/modules/__init__.py
+++ b/src/safe_agent/modules/__init__.py
@@ -22,6 +22,10 @@ from safe_agent.modules.base import (
     ToolResult,
 )
 from safe_agent.modules.database import DatabaseBackend, DatabaseModule
+from safe_agent.modules.error_tracking import (
+    ErrorTrackingBackend,
+    ErrorTrackingModule,
+)
 from safe_agent.modules.messaging import MessagingBackend, MessagingModule
 from safe_agent.modules.registry import ModuleRegistry
 from safe_agent.modules.vault import VaultBackend, VaultModule
@@ -32,6 +36,8 @@ __all__ = [
     "BaseModule",
     "DatabaseBackend",
     "DatabaseModule",
+    "ErrorTrackingBackend",
+    "ErrorTrackingModule",
     "MessagingBackend",
     "MessagingModule",
     "ModuleDescriptor",

--- a/src/safe_agent/modules/error_tracking.py
+++ b/src/safe_agent/modules/error_tracking.py
@@ -1,0 +1,217 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Pluggable error tracking module for SafeAgent.
+
+This module provides an error tracking interface that delegates to an injected
+backend provider. The framework defines the interface; a plugin provides the
+concrete implementation (Sentry, Rollbar, Bugsnag, etc.).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+from safe_agent.modules.base import (
+    BaseModule,
+    ModuleDescriptor,
+    ToolDescriptor,
+    ToolResult,
+)
+
+
+@runtime_checkable
+class ErrorTrackingBackend(Protocol):
+    """Protocol for error tracking backend implementations.
+
+    Implementations provide concrete integrations with error tracking platforms
+    such as Sentry, Rollbar, Bugsnag, etc.
+
+    Methods:
+        query_errors: Query errors for a project with optional filters.
+    """
+
+    async def query_errors(
+        self,
+        project: str,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        """Query errors for a project.
+
+        Args:
+            project: Project identifier to query errors for.
+            **kwargs: Optional filters (query, time_range, limit, etc.).
+
+        Returns:
+            List of error dicts with details (id, type, message, count, etc.).
+        """
+        ...
+
+
+class ErrorTrackingModule(BaseModule):
+    """Error tracking module using the pluggable adapter pattern.
+
+    This module exposes error tracking tools to the SafeAgent framework while
+    delegating actual error queries to an injected backend provider.
+
+    Attributes:
+        _backend: The error tracking backend implementation (private).
+    """
+
+    def __init__(self, backend: ErrorTrackingBackend) -> None:
+        """Initialize the error tracking module with a backend provider.
+
+        Args:
+            backend: An implementation of ErrorTrackingBackend that handles
+                actual error queries for a specific platform.
+        """
+        self._backend = backend
+
+    def describe(self) -> ModuleDescriptor:
+        """Return the error tracking module descriptor and tool definitions."""
+        return ModuleDescriptor(
+            namespace="error_tracking",
+            description="Query and analyze errors from error tracking platforms.",
+            tools=[
+                ToolDescriptor(
+                    name="error_tracking:query_errors",
+                    description="Query errors for a project with optional filters.",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "project": {
+                                "type": "string",
+                                "description": (
+                                    "Project identifier to query errors for."
+                                ),
+                            },
+                            "query": {
+                                "type": "string",
+                                "description": (
+                                    "Optional search query to filter errors."
+                                ),
+                            },
+                            "time_range": {
+                                "type": "string",
+                                "description": (
+                                    "Optional time range filter (e.g., '24h', '7d')."
+                                ),
+                            },
+                            "limit": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "description": (
+                                    "Optional maximum number of errors to return."
+                                ),
+                            },
+                        },
+                        "required": ["project"],
+                        "additionalProperties": False,
+                    },
+                    action="error_tracking:QueryErrors",
+                    resource_param=["project"],
+                    condition_keys=[
+                        "error_tracking:Project",
+                        "error_tracking:ErrorType",
+                    ],
+                ),
+            ],
+        )
+
+    async def resolve_conditions(
+        self,
+        tool_name: str,
+        params: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Resolve error tracking condition values from the parameters.
+
+        Derives condition keys for policy evaluation:
+            - error_tracking:Project: The project identifier.
+            - error_tracking:ErrorType: Inferred from query if present.
+
+        Args:
+            tool_name: The name of the tool being invoked.
+            params: The input parameters for the invocation.
+
+        Returns:
+            Dict mapping condition keys to resolved values.
+        """
+        project = params.get("project")
+        if project is None:
+            return {}
+
+        project_str = str(project)
+        conditions: dict[str, Any] = {
+            "error_tracking:Project": project_str,
+        }
+
+        # Infer ErrorType from query if it contains type information.
+        # This is a simple heuristic - backends may have more sophisticated
+        # type detection.
+        query = params.get("query")
+        if query is not None and isinstance(query, str):
+            # Look for common error type patterns in query
+            # e.g., "type:TypeError" or "error_type:ValueError"
+            query_lower = query.lower()
+            for prefix in ("type:", "error_type:", "error:"):
+                if prefix in query_lower:
+                    # Extract the type value after the prefix
+                    start = query_lower.find(prefix) + len(prefix)
+                    remaining = query[start:]
+                    # Extract until next space or end
+                    end = remaining.find(" ")
+                    if end == -1:
+                        end = len(remaining)
+                    error_type = remaining[:end].strip()
+                    if error_type:
+                        conditions["error_tracking:ErrorType"] = error_type
+                        break
+
+        return conditions
+
+    async def execute(
+        self,
+        tool_name: str,
+        params: dict[str, Any],
+    ) -> ToolResult[Any]:
+        """Execute an error tracking tool invocation by delegating to the backend.
+
+        Args:
+            tool_name: The name of the tool to execute.
+            params: The input parameters for the tool.
+
+        Returns:
+            A ToolResult indicating success or failure, plus any data.
+        """
+        try:
+            normalized_tool = tool_name.removeprefix("error_tracking:")
+            if normalized_tool == "query_errors":
+                return await self._query_errors(params)
+            return ToolResult(success=False, error=f"Unknown tool: {tool_name}")
+        except Exception as exc:
+            return ToolResult(success=False, error=str(exc))
+
+    async def _query_errors(self, params: dict[str, Any]) -> ToolResult[Any]:
+        """Delegate error querying to the backend."""
+        project = str(params["project"])
+        kwargs: dict[str, Any] = {}
+        if "query" in params:
+            kwargs["query"] = params["query"]
+        if "time_range" in params:
+            kwargs["time_range"] = params["time_range"]
+        if "limit" in params:
+            kwargs["limit"] = params["limit"]
+
+        errors = await self._backend.query_errors(project, **kwargs)
+        return ToolResult(success=True, data={"errors": errors})

--- a/tests/test_modules/test_error_tracking.py
+++ b/tests/test_modules/test_error_tracking.py
@@ -1,0 +1,257 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the pluggable error tracking module."""
+
+from typing import Any
+
+from safe_agent.modules.error_tracking import (
+    ErrorTrackingBackend,
+    ErrorTrackingModule,
+)
+
+
+class MockErrorTrackingBackend:
+    """Mock backend for testing ErrorTrackingModule."""
+
+    def __init__(self) -> None:
+        """Initialize mock backend with storage for errors."""
+        self.stored_errors: dict[str, list[dict[str, Any]]] = {}
+        # Track kwargs passed to query_errors
+        self.last_query_kwargs: dict[str, Any] = {}
+
+    async def query_errors(
+        self,
+        project: str,
+        **kwargs: Any,
+    ) -> list[dict[str, Any]]:
+        """Mock query_errors that returns stored errors for the project."""
+        self.last_query_kwargs = kwargs  # Track what kwargs were passed
+        errors = self.stored_errors.get(project, [])
+        return errors
+
+
+class TestErrorTrackingModule:
+    """Tests for ErrorTrackingModule operations and descriptors."""
+
+    def test_describe_returns_valid_descriptor(self) -> None:
+        """describe() should return the expected module metadata."""
+        backend = MockErrorTrackingBackend()
+        module = ErrorTrackingModule(backend)
+
+        descriptor = module.describe()
+
+        assert descriptor.namespace == "error_tracking"
+        assert len(descriptor.tools) == 1
+        assert descriptor.tools[0].name == "error_tracking:query_errors"
+
+    def test_describe_tool_has_correct_action_and_resource_param(self) -> None:
+        """Tool should have correct action name and resource param."""
+        backend = MockErrorTrackingBackend()
+        module = ErrorTrackingModule(backend)
+
+        descriptor = module.describe()
+
+        tool = descriptor.tools[0]
+        assert tool.action == "error_tracking:QueryErrors"
+        assert tool.resource_param == ["project"]
+        assert tool.condition_keys == [
+            "error_tracking:Project",
+            "error_tracking:ErrorType",
+        ]
+
+    def test_backend_protocol_check(self) -> None:
+        """MockErrorTrackingBackend should satisfy the ErrorTrackingBackend protocol."""
+        backend = MockErrorTrackingBackend()
+        assert isinstance(backend, ErrorTrackingBackend)
+
+    async def test_query_errors_delegates_to_backend(self) -> None:
+        """query_errors should delegate to the backend and return success."""
+        backend = MockErrorTrackingBackend()
+        backend.stored_errors["my-project"] = [
+            {"id": "err-1", "type": "TypeError", "message": "Cannot read property"},
+            {"id": "err-2", "type": "ValueError", "message": "Invalid value"},
+        ]
+        module = ErrorTrackingModule(backend)
+
+        result = await module.execute(
+            "error_tracking:query_errors",
+            {"project": "my-project"},
+        )
+
+        assert result.success is True
+        assert result.data == {
+            "errors": [
+                {"id": "err-1", "type": "TypeError", "message": "Cannot read property"},
+                {"id": "err-2", "type": "ValueError", "message": "Invalid value"},
+            ]
+        }
+
+    async def test_query_errors_with_optional_params(self) -> None:
+        """query_errors should pass through optional query, time_range, limit."""
+        backend = MockErrorTrackingBackend()
+        backend.stored_errors["my-project"] = [
+            {"id": "err-1", "type": "TypeError", "message": "Cannot read property"},
+        ]
+        module = ErrorTrackingModule(backend)
+
+        result = await module.execute(
+            "error_tracking:query_errors",
+            {
+                "project": "my-project",
+                "query": "TypeError",
+                "time_range": "24h",
+                "limit": 10,
+            },
+        )
+
+        assert result.success is True
+        assert result.data == {
+            "errors": [
+                {"id": "err-1", "type": "TypeError", "message": "Cannot read property"},
+            ]
+        }
+        # Verify the kwargs were actually forwarded to the backend
+        assert backend.last_query_kwargs.get("query") == "TypeError"
+        assert backend.last_query_kwargs.get("time_range") == "24h"
+        assert backend.last_query_kwargs.get("limit") == 10
+
+    async def test_execute_returns_error_for_unknown_tool(self) -> None:
+        """Execute should return error for unknown tool names."""
+        backend = MockErrorTrackingBackend()
+        module = ErrorTrackingModule(backend)
+
+        result = await module.execute(
+            "error_tracking:unknown_tool",
+            {"project": "my-project"},
+        )
+
+        assert result.success is False
+        assert result.error == "Unknown tool: error_tracking:unknown_tool"
+
+    async def test_backend_error_propagates_as_tool_result_error(self) -> None:
+        """Backend errors should be caught and returned as ToolResult errors."""
+
+        class FailingBackend(MockErrorTrackingBackend):
+            async def query_errors(
+                self, project: str, **kwargs: Any
+            ) -> list[dict[str, Any]]:
+                raise RuntimeError("API connection failed")
+
+        backend = FailingBackend()
+        module = ErrorTrackingModule(backend)
+
+        result = await module.execute(
+            "error_tracking:query_errors",
+            {"project": "my-project"},
+        )
+
+        assert result.success is False
+        assert result.error == "API connection failed"
+
+    async def test_resolve_conditions_derives_project(self) -> None:
+        """resolve_conditions should derive error_tracking:Project from params."""
+        backend = MockErrorTrackingBackend()
+        module = ErrorTrackingModule(backend)
+
+        conditions = await module.resolve_conditions(
+            "error_tracking:query_errors",
+            {"project": "my-project"},
+        )
+
+        assert conditions == {
+            "error_tracking:Project": "my-project",
+        }
+
+    async def test_resolve_conditions_infers_error_type_from_query(self) -> None:
+        """resolve_conditions should infer error_tracking:ErrorType from query."""
+        backend = MockErrorTrackingBackend()
+        module = ErrorTrackingModule(backend)
+
+        # Test type: prefix
+        conditions = await module.resolve_conditions(
+            "error_tracking:query_errors",
+            {"project": "my-project", "query": "type:TypeError"},
+        )
+
+        assert conditions == {
+            "error_tracking:Project": "my-project",
+            "error_tracking:ErrorType": "TypeError",
+        }
+
+        # Test error_type: prefix
+        conditions = await module.resolve_conditions(
+            "error_tracking:query_errors",
+            {"project": "my-project", "query": "error_type:ValueError"},
+        )
+
+        assert conditions == {
+            "error_tracking:Project": "my-project",
+            "error_tracking:ErrorType": "ValueError",
+        }
+
+        # Test error: prefix
+        conditions = await module.resolve_conditions(
+            "error_tracking:query_errors",
+            {"project": "my-project", "query": "error:RuntimeError"},
+        )
+
+        assert conditions == {
+            "error_tracking:Project": "my-project",
+            "error_tracking:ErrorType": "RuntimeError",
+        }
+
+    async def test_resolve_conditions_no_error_type_without_query(self) -> None:
+        """resolve_conditions should not add ErrorType if no query present."""
+        backend = MockErrorTrackingBackend()
+        module = ErrorTrackingModule(backend)
+
+        conditions = await module.resolve_conditions(
+            "error_tracking:query_errors",
+            {"project": "my-project", "limit": 10},
+        )
+
+        assert conditions == {
+            "error_tracking:Project": "my-project",
+        }
+
+    async def test_resolve_conditions_no_error_type_without_type_in_query(
+        self,
+    ) -> None:
+        """resolve_conditions should not add ErrorType if query lacks type prefix."""
+        backend = MockErrorTrackingBackend()
+        module = ErrorTrackingModule(backend)
+
+        conditions = await module.resolve_conditions(
+            "error_tracking:query_errors",
+            {"project": "my-project", "query": "database connection failed"},
+        )
+
+        assert conditions == {
+            "error_tracking:Project": "my-project",
+        }
+
+    async def test_resolve_conditions_returns_empty_for_missing_project(
+        self,
+    ) -> None:
+        """resolve_conditions should return empty dict if project is missing."""
+        backend = MockErrorTrackingBackend()
+        module = ErrorTrackingModule(backend)
+
+        conditions = await module.resolve_conditions(
+            "error_tracking:query_errors",
+            {"query": "TypeError"},
+        )
+
+        assert conditions == {}


### PR DESCRIPTION
Implements error_tracking interface module using the pluggable adapter pattern.

## Changes

- **Protocol**: `ErrorTrackingBackend` with `query_errors()` method
- **Module**: `ErrorTrackingModule` with backend injection via `__init__`
- **Tool**: `error_tracking:query_errors` accepts project, query, time_range, limit
- **Condition keys**: `error_tracking:Project`, `error_tracking:ErrorType`
- **Tests**: 12 tests with mock backend covering all acceptance criteria

## Verification

- ✅ ruff check passes
- ✅ ruff format passes
- ✅ mypy --strict passes
- ✅ 562 tests pass (12 new)

Closes #79