### PR TITLE
feat: move observability modules into sub-package (closes #120)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ shell = "safe_agent.modules.shell:ShellModule"
 web_api = "safe_agent.modules.web_api:WebApiModule"
 web_browse = "safe_agent.modules.web_browse:WebBrowseModule"
 remote_ssh = "safe_agent.modules.remote_ssh:RemoteSSHModule"
-audit = "safe_agent.modules.audit:AuditModule"
+audit = "safe_agent.modules.observability.audit:AuditModule"
 scm = "safe_agent.modules.scm:SCMModule"
 
 [project.urls]

--- a/src/safe_agent/modules/__init__.py
+++ b/src/safe_agent/modules/__init__.py
@@ -14,7 +14,6 @@
 
 """SafeAgent modules package — public re-exports."""
 
-from safe_agent.modules.alerting import AlertingBackend, AlertingModule
 from safe_agent.modules.base import (
     BaseModule,
     ModuleDescriptor,
@@ -22,12 +21,21 @@ from safe_agent.modules.base import (
     ToolResult,
 )
 from safe_agent.modules.database import DatabaseBackend, DatabaseModule
-from safe_agent.modules.error_tracking import (
-    ErrorTrackingBackend,
-    ErrorTrackingModule,
-)
 from safe_agent.modules.git import GitModule
 from safe_agent.modules.messaging import MessagingBackend, MessagingModule
+from safe_agent.modules.observability import (
+    AlertingBackend,
+    AlertingModule,
+    AuditModule,
+    DashboardBackend,
+    DashboardModule,
+    ErrorTrackingBackend,
+    ErrorTrackingModule,
+    LoggingBackend,
+    LoggingModule,
+    MetricsBackend,
+    MetricsModule,
+)
 from safe_agent.modules.registry import ModuleRegistry
 from safe_agent.modules.scm import (
     Branch,
@@ -50,9 +58,12 @@ from safe_agent.modules.vault import VaultBackend, VaultModule
 __all__ = [
     "AlertingBackend",
     "AlertingModule",
+    "AuditModule",
     "BaseModule",
     "Branch",
     "Comment",
+    "DashboardBackend",
+    "DashboardModule",
     "DatabaseBackend",
     "DatabaseModule",
     "ErrorTrackingBackend",
@@ -61,8 +72,12 @@ __all__ = [
     "GitLabSCM",
     "GitModule",
     "Issue",
+    "LoggingBackend",
+    "LoggingModule",
     "MessagingBackend",
     "MessagingModule",
+    "MetricsBackend",
+    "MetricsModule",
     "ModuleDescriptor",
     "ModuleRegistry",
     "PullRequest",

--- a/src/safe_agent/modules/observability/__init__.py
+++ b/src/safe_agent/modules/observability/__init__.py
@@ -1,0 +1,62 @@
+# Copyright 2026 Zachary Brooks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Observability modules for SafeAgent.
+
+This sub-package provides monitoring, logging, and observability capabilities:
+- alerting: Alert management through pluggable backends
+- audit: Read-only audit log query interface
+- dashboard: Dashboard panel access for trend analysis
+- error_tracking: Error tracking platform integration
+- logging: Pluggable logging interface
+- metrics: Metrics query interface
+"""
+
+from safe_agent.modules.observability.alerting import (
+    AlertingBackend,
+    AlertingModule,
+)
+from safe_agent.modules.observability.audit import (
+    AuditModule,
+)
+from safe_agent.modules.observability.dashboard import (
+    DashboardBackend,
+    DashboardModule,
+)
+from safe_agent.modules.observability.error_tracking import (
+    ErrorTrackingBackend,
+    ErrorTrackingModule,
+)
+from safe_agent.modules.observability.logging import (
+    LoggingBackend,
+    LoggingModule,
+)
+from safe_agent.modules.observability.metrics import (
+    MetricsBackend,
+    MetricsModule,
+)
+
+__all__ = [
+    "AlertingBackend",
+    "AlertingModule",
+    "AuditModule",
+    "DashboardBackend",
+    "DashboardModule",
+    "ErrorTrackingBackend",
+    "ErrorTrackingModule",
+    "LoggingBackend",
+    "LoggingModule",
+    "MetricsBackend",
+    "MetricsModule",
+]

--- a/src/safe_agent/modules/observability/alerting.py
+++ b/src/safe_agent/modules/observability/alerting.py
@@ -40,6 +40,10 @@ from safe_agent.modules.base import (
     ToolResult,
 )
 
+# Note: This module is now at safe_agent.modules.observability.alerting
+# but imports from safe_agent.modules.base remain unchanged since base.py
+# is in the parent modules/ directory.
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/safe_agent/modules/observability/audit.py
+++ b/src/safe_agent/modules/observability/audit.py
@@ -30,6 +30,10 @@ from safe_agent.modules.base import (
     ToolResult,
 )
 
+# Note: This module is now at safe_agent.modules.observability.audit
+# but imports from safe_agent.modules.base remain unchanged since base.py
+# is in the parent modules/ directory.
+
 logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_RESULTS = 1000

--- a/src/safe_agent/modules/observability/dashboard.py
+++ b/src/safe_agent/modules/observability/dashboard.py
@@ -26,6 +26,10 @@ from safe_agent.modules.base import (
     ToolResult,
 )
 
+# Note: This module is now at safe_agent.modules.observability.dashboard
+# but imports from safe_agent.modules.base remain unchanged since base.py
+# is in the parent modules/ directory.
+
 logger = logging.getLogger(__name__)
 
 

--- a/src/safe_agent/modules/observability/error_tracking.py
+++ b/src/safe_agent/modules/observability/error_tracking.py
@@ -30,6 +30,10 @@ from safe_agent.modules.base import (
     ToolResult,
 )
 
+# Note: This module is now at safe_agent.modules.observability.error_tracking
+# but imports from safe_agent.modules.base remain unchanged since base.py
+# is in the parent modules/ directory.
+
 
 @runtime_checkable
 class ErrorTrackingBackend(Protocol):

--- a/src/safe_agent/modules/observability/logging.py
+++ b/src/safe_agent/modules/observability/logging.py
@@ -31,6 +31,10 @@ from safe_agent.modules.base import (
     ToolResult,
 )
 
+# Note: This module is now at safe_agent.modules.observability.logging
+# but imports from safe_agent.modules.base remain unchanged since base.py
+# is in the parent modules/ directory.
+
 logger = stdlib_logging.getLogger(__name__)
 
 

--- a/src/safe_agent/modules/observability/metrics.py
+++ b/src/safe_agent/modules/observability/metrics.py
@@ -32,6 +32,10 @@ from safe_agent.modules.base import (
     ToolResult,
 )
 
+# Note: This module is now at safe_agent.modules.observability.metrics
+# but imports from safe_agent.modules.base remain unchanged since base.py
+# is in the parent modules/ directory.
+
 logger = logging.getLogger(__name__)
 
 __all__ = ["MetricsBackend", "MetricsModule"]

--- a/tests/test_modules/test_alerting.py
+++ b/tests/test_modules/test_alerting.py
@@ -16,7 +16,7 @@
 
 from unittest.mock import AsyncMock
 
-from safe_agent.modules.alerting import AlertingModule
+from safe_agent.modules.observability.alerting import AlertingModule
 
 
 class MockAlertingBackend:

--- a/tests/test_modules/test_audit.py
+++ b/tests/test_modules/test_audit.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import pytest
 
-from safe_agent.modules.audit import DEFAULT_MAX_RESULTS, AuditModule
+from safe_agent.modules.observability.audit import DEFAULT_MAX_RESULTS, AuditModule
 
 
 class TestAuditModuleDescriptor:

--- a/tests/test_modules/test_dashboard.py
+++ b/tests/test_modules/test_dashboard.py
@@ -17,7 +17,7 @@
 
 from typing import Any
 
-from safe_agent.modules.dashboard import DashboardModule
+from safe_agent.modules.observability.dashboard import DashboardModule
 
 
 class MockDashboardBackend:

--- a/tests/test_modules/test_error_tracking.py
+++ b/tests/test_modules/test_error_tracking.py
@@ -16,7 +16,7 @@
 
 from typing import Any
 
-from safe_agent.modules.error_tracking import (
+from safe_agent.modules.observability.error_tracking import (
     ErrorTrackingBackend,
     ErrorTrackingModule,
 )

--- a/tests/test_modules/test_logging.py
+++ b/tests/test_modules/test_logging.py
@@ -16,7 +16,7 @@
 
 from unittest.mock import AsyncMock
 
-from safe_agent.modules.logging import LoggingBackend, LoggingModule
+from safe_agent.modules.observability.logging import LoggingBackend, LoggingModule
 
 
 class MockLoggingBackend:

--- a/tests/test_modules/test_metrics.py
+++ b/tests/test_modules/test_metrics.py
@@ -16,7 +16,7 @@
 
 from unittest.mock import AsyncMock
 
-from safe_agent.modules.metrics import MetricsModule
+from safe_agent.modules.observability.metrics import MetricsModule
 
 
 class MockMetricsBackend:


### PR DESCRIPTION
This PR implements #120 by moving all observability-related modules into a dedicated `modules/observability/` sub-package.

## Changes
- Created `src/safe_agent/modules/observability/` with `__init__.py`
- Moved 6 modules:
  - `alerting.py` → `observability/alerting.py`
  - `audit.py` → `observability/audit.py`
  - `dashboard.py` → `observability/dashboard.py`
  - `error_tracking.py` → `observability/error_tracking.py`
  - `logging.py` → `observability/logging.py`
  - `metrics.py` → `observability/metrics.py`
- Updated `modules/__init__.py` imports and added missing re-exports
- Updated `pyproject.toml` entry points
- Updated all test imports

## Verification
- All 925 tests pass ✅

Closes #120