### PR TITLE
fix: eliminate timing-fragile tests via clock abstraction

### DIFF
--- a/src/safe_agent/core/session.py
+++ b/src/safe_agent/core/session.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import contextlib
 import threading
+import time
 from collections import OrderedDict
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
@@ -54,7 +55,7 @@ class Session(BaseModel):
     max_messages: int = Field(default=1000, gt=0)
     metadata: dict = Field(default_factory=dict)
     created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
-    last_accessed: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    last_accessed: float = Field(default_factory=time.monotonic)
 
     #: Per-session reentrant lock protecting ``messages``.
     #: Excluded from serialisation; created fresh for each Session instance.
@@ -83,6 +84,7 @@ class SessionManager:
         session_ttl: timedelta | float | None = None,
         max_sessions: int | None = None,
         max_messages: int | None = None,
+        clock: Callable[[], float] | None = None,
     ) -> None:
         """Initialize session manager with optional limits.
 
@@ -91,17 +93,25 @@ class SessionManager:
                 or float (interpreted as seconds). Default is 1 hour (3600 seconds).
             max_sessions: Maximum concurrent sessions. Default is 1000.
             max_messages: Maximum messages per session. Default is 1000.
+            clock: Optional clock function returning monotonic time as float.
+                Defaults to time.monotonic. Used for testing with fake clocks.
         """
-        # Normalize TTL to timedelta
+        # Store clock (for testing)
+        self._clock = clock or time.monotonic
+
+        # Normalize TTL to float seconds for comparison
         if session_ttl is None:
-            self.session_ttl = timedelta(seconds=3600)  # 1 hour default
+            self._session_ttl_seconds = 3600.0  # 1 hour default
         elif isinstance(session_ttl, timedelta):
-            self.session_ttl = session_ttl
+            self._session_ttl_seconds = session_ttl.total_seconds()
         else:
-            self.session_ttl = timedelta(seconds=session_ttl)
+            self._session_ttl_seconds = float(session_ttl)
+
+        # Also store as timedelta for backward compatibility
+        self.session_ttl = timedelta(seconds=self._session_ttl_seconds)
 
         # Validate TTL is non-negative
-        if self.session_ttl.total_seconds() < 0:
+        if self._session_ttl_seconds < 0:
             raise ValueError("session_ttl must be non-negative")
 
         # Apply defaults
@@ -138,6 +148,8 @@ class SessionManager:
                 self._evict_lru()
 
             session = Session(max_messages=self.max_messages)
+            # Use the manager's clock for last_accessed (important for testing)
+            session.last_accessed = self._clock()
             self._sessions[session.id] = session
             # Move to end (most recently used)
             self._sessions.move_to_end(session.id)
@@ -163,7 +175,7 @@ class SessionManager:
                 return None
 
             # Update access time and move to end (most recently used)
-            session.last_accessed = datetime.now(UTC)
+            session.last_accessed = self._clock()
             self._sessions.move_to_end(session_id)
             return session
 
@@ -220,7 +232,7 @@ class SessionManager:
             if session is None:
                 return None
             # Update access time and LRU position while holding the manager lock.
-            session.last_accessed = datetime.now(UTC)
+            session.last_accessed = self._clock()
             self._sessions.move_to_end(session_id)
 
         # Protect the actual message mutation with the per-session lock so that
@@ -265,12 +277,12 @@ class SessionManager:
         Returns:
             Number of sessions evicted.
         """
-        now = datetime.now(UTC)
+        now = self._clock()
         expired_ids = []
 
         for session_id, session in self._sessions.items():
             idle_time = now - session.last_accessed
-            if idle_time > self.session_ttl:
+            if idle_time > self._session_ttl_seconds:
                 expired_ids.append(session_id)
 
         for session_id in expired_ids:

--- a/tests/test_core/test_session.py
+++ b/tests/test_core/test_session.py
@@ -16,11 +16,28 @@
 """Tests for Session and SessionManager with TTL and eviction."""
 
 import threading
-import time
 from datetime import timedelta
 from uuid import UUID
 
 from safe_agent.core import SessionManager
+
+
+class FakeClock:
+    """A fake clock for deterministic testing of TTL behavior.
+
+    Implements the clock protocol (Callable[[], float]) used by SessionManager.
+    Time is controlled manually via advance() instead of relying on real time.
+    """
+
+    def __init__(self, start: float = 0.0) -> None:
+        self._time = start
+
+    def __call__(self) -> float:
+        return self._time
+
+    def advance(self, seconds: float) -> None:
+        """Advance the fake clock by the given number of seconds."""
+        self._time += seconds
 
 
 class TestSessionBasics:
@@ -95,7 +112,8 @@ class TestSessionTTL:
         assert manager.session_ttl == timedelta(seconds=1800)
 
     def test_expired_session_not_returned(self) -> None:
-        manager = SessionManager(session_ttl=0.1)  # 100ms TTL
+        fake_time = FakeClock(start=0.0)
+        manager = SessionManager(session_ttl=0.1, clock=fake_time)  # 100ms TTL
 
         session = manager.create()
         session_id = session.id
@@ -103,48 +121,51 @@ class TestSessionTTL:
         # Session should be present initially
         assert manager.get(session_id) is not None
 
-        # Wait for TTL to expire
-        time.sleep(0.15)
+        # Advance time past TTL
+        fake_time.advance(0.15)  # 150ms
 
         # Expired session should be cleaned up on access
         assert manager.get(session_id) is None
 
     def test_expired_sessions_removed_on_list_active(self) -> None:
-        manager = SessionManager(session_ttl=0.1)  # 100ms TTL
+        fake_time = FakeClock(start=0.0)
+        manager = SessionManager(session_ttl=0.1, clock=fake_time)  # 100ms TTL
 
         session = manager.create()
 
         # Session should be in list initially
         assert session.id in manager.list_active()
 
-        # Wait for TTL to expire
-        time.sleep(0.15)
+        # Advance time past TTL
+        fake_time.advance(0.15)  # 150ms
 
         # Should be cleaned up on list_active
         assert session.id not in manager.list_active()
 
     def test_accessed_session_not_expired(self) -> None:
-        manager = SessionManager(session_ttl=0.2)  # 200ms TTL
+        fake_time = FakeClock(start=0.0)
+        manager = SessionManager(session_ttl=0.2, clock=fake_time)  # 200ms TTL
 
         session = manager.create()
         session_id = session.id
 
         # Keep accessing the session to keep it alive
         for _ in range(3):
-            time.sleep(0.1)
+            fake_time.advance(0.1)  # Advance 100ms each time
             assert manager.get(session_id) is not None
 
         # Should still exist after 300ms total because we kept accessing
         assert manager.get(session_id) is not None
 
     def test_last_accessed_updated_on_get(self) -> None:
-        manager = SessionManager(session_ttl=3600)
+        fake_time = FakeClock(start=0.0)
+        manager = SessionManager(session_ttl=3600, clock=fake_time)
 
         session = manager.create()
         initial_access = session.last_accessed
 
-        # Small delay
-        time.sleep(0.01)
+        # Advance time
+        fake_time.advance(0.01)
 
         manager.get(session.id)
         assert session.last_accessed > initial_access
@@ -265,13 +286,14 @@ class TestEvictionCallback:
 
     def test_eviction_callback_on_ttl_expiry(self) -> None:
         evicted = []
-        manager = SessionManager(session_ttl=0.1)
+        fake_time = FakeClock(start=0.0)
+        manager = SessionManager(session_ttl=0.1, clock=fake_time)
         manager.set_eviction_callback(lambda s: evicted.append(s.id))
 
         session = manager.create()
 
-        # Wait for TTL
-        time.sleep(0.15)
+        # Advance time past TTL
+        fake_time.advance(0.15)  # 150ms
 
         # Trigger cleanup via get
         manager.get(session.id)
@@ -502,24 +524,26 @@ class TestCleanupConsistency:
     """Tests for cleanup behavior across all methods."""
 
     def test_count_triggers_cleanup(self) -> None:
-        manager = SessionManager(session_ttl=0.1)
+        fake_time = FakeClock(start=0.0)
+        manager = SessionManager(session_ttl=0.1, clock=fake_time)
 
         manager.create()
 
-        # Wait for TTL
-        time.sleep(0.15)
+        # Advance time past TTL
+        fake_time.advance(0.15)  # 150ms
 
         # count() should trigger cleanup
         assert manager.count() == 0
 
     def test_close_triggers_cleanup(self) -> None:
-        manager = SessionManager(session_ttl=0.1)
+        fake_time = FakeClock(start=0.0)
+        manager = SessionManager(session_ttl=0.1, clock=fake_time)
 
         session1 = manager.create()
         _ = manager.create()
 
-        # Wait for TTL
-        time.sleep(0.15)
+        # Advance time past TTL
+        fake_time.advance(0.15)  # 150ms
 
         # close() should trigger cleanup
         manager.close(session1.id)


### PR DESCRIPTION
## Summary

Replace real `time.sleep()` calls with a FakeClock for deterministic TTL testing. This removes the 50ms margin race conditions that caused flaky tests on slow CI runners.

## Changes

- SessionManager now accepts an optional `clock` callable (defaults to `time.monotonic` for production)
- Session.last_accessed changed from `datetime` to `float` for efficient comparison
- Added FakeClock test helper with `advance()` method
- Updated 7 timing-dependent tests to use FakeClock instead of real time.sleep()

## Acceptance Criteria

- [x] All timing-dependent session tests are deterministic (no real time.sleep)
- [x] Tests pass reliably on slow CI runners
- [x] No test takes more than 1 second due to sleep

## Testing

All 42 tests in `test_session.py` pass:
```
pytest tests/test_core/test_session.py -v
# 42 passed in 0.31s
```

Fixes #140