### PR TITLE
fix: MockLLM returns unconstrained Mock() in test_agent.py (fixes #141)

### DIFF
--- a/tests/test_core/test_agent.py
+++ b/tests/test_core/test_agent.py
@@ -23,7 +23,7 @@ from unittest.mock import Mock, patch
 import pytest
 
 from safe_agent import Agent
-from safe_agent.core.llm import LLMClient
+from safe_agent.core.llm import LLMClient, LLMResponse
 from safe_agent.modules.base import BaseModule
 
 
@@ -33,9 +33,9 @@ class MockLLM(LLMClient):
     def __init__(self) -> None:
         self.chat_calls: list[tuple[list, list]] = []
 
-    async def chat(self, messages: list, tools: list) -> None:
+    async def chat(self, messages: list, tools: list) -> LLMResponse:
         self.chat_calls.append((messages, tools))
-        return Mock()
+        return LLMResponse(content="mock response")
 
 
 class MockModule(BaseModule):

--- a/tests/test_integration/test_end_to_end.py
+++ b/tests/test_integration/test_end_to_end.py
@@ -209,7 +209,7 @@ async def test_denied_tool_call_returns_generic_error(tmp_path: Path) -> None:
             LLMResponse(
                 tool_calls=[
                     ToolCall(
-                        name="test:echo",
+                        name="test__echo",
                         params={"target": "denied-resource", "message": "secret"},
                     )
                 ]
@@ -250,7 +250,7 @@ async def test_audit_log_contains_entries_for_all_decisions(tmp_path: Path) -> N
             LLMResponse(
                 tool_calls=[
                     ToolCall(
-                        name="test:echo",
+                        name="test__echo",
                         params={
                             "target": "allowed-resource",
                             "message": "hello",
@@ -262,7 +262,7 @@ async def test_audit_log_contains_entries_for_all_decisions(tmp_path: Path) -> N
             LLMResponse(
                 tool_calls=[
                     ToolCall(
-                        name="test:echo",
+                        name="test__echo",
                         params={
                             "target": "denied-resource",
                             "message": "hello",


### PR DESCRIPTION
Fixes #141

## Summary

This PR addresses two test quality issues that can mask real bugs:

### 1. Unconstrained Mock() return in MockLLM

tests/test_core/test_agent.py lines 30-38:

- Changed MockLLM.chat() to return a properly structured LLMResponse instead of unconstrained Mock()
- Fixed return type annotation from `-> None` to `-> LLMResponse`

The previous Mock() has every attribute and method, so downstream code could call any arbitrary method without triggering an AttributeError. Now tests properly validate the actual response structure.

### 2. Inconsistent tool name formats in e2e tests

tests/test_integration/test_end_to_end.py:

- Changed "test:echo" to "test__echo" (sanitized format) on lines 210, 253, 264
- Ensures consistent use of sanitized tool names across all ToolCall constructions

## Verification

- All tests in test_agent.py pass (12 tests)
- All tests in test_end_to_end.py pass (7 tests)
- Ruff check and format pass
- Pre-commit hooks pass